### PR TITLE
Multiple "Error Reserved variable in expression" fixes

### DIFF
--- a/Altis_Life.Altis/core/fn_setupStationService.sqf
+++ b/Altis_Life.Altis/core/fn_setupStationService.sqf
@@ -156,5 +156,6 @@ private _stationPositions = ALTIS_TANOA(_altisPositions,_tanoaPositions);
 {
     private _pump = nearestObjects [_x,["Land_fs_feed_F","Land_FuelStation_01_pump_F","Land_FuelStation_02_pump_F"],5] select 0;
     _pump setFuelCargo 0;
-    nil = _pump addAction [localize "STR_Action_Pump", life_fnc_fuelStatOpen, 1, 3, true, true, "", '_this distance _target < 5 && cursorObject isEqualTo _target'];
+    _pump addAction [localize "STR_Action_Pump", life_fnc_fuelStatOpen, 1, 3, true, true, "", '_this distance _target < 5 && cursorObject isEqualTo _target'];
+    false
 } count _stationPositions;

--- a/Altis_Life.Altis/core/init.sqf
+++ b/Altis_Life.Altis/core/init.sqf
@@ -160,7 +160,8 @@ if (life_HC_isActive) then {
 life_hideoutBuildings = [];
 {
     private _building = nearestBuilding getMarkerPos _x;
-    nil = life_hideoutBuildings pushBack _building;
+    life_hideoutBuildings pushBack _building;
+    false
 } count ["gang_area_1","gang_area_2","gang_area_3"];
 
 diag_log "----------------------------------------------------------------------------------------------------";

--- a/life_server/Functions/WantedSystem/fn_wantedCrimes.sqf
+++ b/life_server/Functions/WantedSystem/fn_wantedCrimes.sqf
@@ -26,7 +26,8 @@ if (_type isEqualType "") then {_type = call compile format ["%1", _type];};
 private _crimesArr = [];
 {
     private _str = format ["STR_Crime_%1", _x];
-    nil = _crimesArr pushBack _str;
+    _crimesArr pushBack _str;
+    false
 } count _type;
 
 _queryResult set[0,_crimesArr];

--- a/life_server/Functions/WantedSystem/fn_wantedFetch.sqf
+++ b/life_server/Functions/WantedSystem/fn_wantedFetch.sqf
@@ -16,7 +16,8 @@ private _inStatement = "";
 private _list = [];
 private _units = [];
 {
-    nil = if (side _x isEqualTo civilian) then {_units pushBack (getPlayerUID _x)};
+    if (side _x isEqualTo civilian) then {_units pushBack (getPlayerUID _x)};
+    false
 } count playableUnits;
 
 if (count _units isEqualTo 0) exitWith {[_list] remoteExec ["life_fnc_wantedList",_ret];};
@@ -40,7 +41,8 @@ if (EXTDB_SETTING(getNumber,"DebugMode") isEqualTo 1) then {
 };
 
 {
-    nil = _list pushBack _x;
+    _list pushBack _x;
+    false
 } count _queryResult;
 
 if (count _list isEqualTo 0) exitWith {[_list] remoteExec ["life_fnc_wantedList",_ret];};


### PR DESCRIPTION
Resolves four error in expressions relating to Reserved variable. 
Client/local RPT: 

```
 2:14:05 Error in expression <,5] select 0;
_pump setFuelCargo 0;
nil = _pump addAction [localize "STR_Action_>
 2:14:05   Error position: <= _pump addAction [localize "STR_Action_>
 2:14:05   Error Reserved variable in expression
 2:14:05 File mpmissions\__CUR_MP.Altis\core\fn_setupStationService.sqf, line 159
 2:14:05 Error in expression < = nearestBuilding getMarkerPos _x;
nil = life_hideoutBuildings pushBack _buildi>
 2:14:05   Error position: <= life_hideoutBuildings pushBack _buildi>
 2:14:05   Error Reserved variable in expression
 2:14:05 File mpmissions\__CUR_MP.Altis\core\init.sqf, line 163
```

#### Changes proposed in this pull request: 
- Fixes error in expressions for: 
  - fn_setupStationService 
  - core/init 
  - fn_wantedCrimes 
  - fn_wantedFetch 
- Courtesy of @BoGuu. 

Tested and working on the [latest build](https://github.com/AsYetUntitled/Framework/commit/419aae8cb3327c4ae7c3f9303786819adc2a6140) and in _Arma 3_ version [1.64](https://dev.arma3.com/post/spotrep-00060). 
