### PR TITLE
isEqualTo and objectParent Optimisation

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_gather.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gather.sqf
@@ -8,7 +8,7 @@
 */
 private ["_maxGather","_resource","_amount","_maxGather","_requiredItem"];
 if (life_action_inUse) exitWith {};
-if ((vehicle player) != player) exitWith {};
+if !((vehicle player) isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 

--- a/Altis_Life.Altis/core/actions/fn_gather.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gather.sqf
@@ -8,7 +8,7 @@
 */
 private ["_maxGather","_resource","_amount","_maxGather","_requiredItem"];
 if (life_action_inUse) exitWith {};
-if !(vehicle player isEqualTo player) exitWith {};
+if !(isNull objectParent player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 

--- a/Altis_Life.Altis/core/actions/fn_gather.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gather.sqf
@@ -8,7 +8,7 @@
 */
 private ["_maxGather","_resource","_amount","_maxGather","_requiredItem"];
 if (life_action_inUse) exitWith {};
-if !((vehicle player) isEqualTo player) exitWith {};
+if !(vehicle player isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 

--- a/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
@@ -49,7 +49,7 @@ for "_i" from 0 to 1 step 0 do {
     if (_cP >= 1) exitWith {};
     if (!alive player) exitWith {};
     if (isNull _animalCorpse) exitWith {};
-    if !(vehicle player isEqualTo player) exitWith {};
+    if !(isNull objectParent player) exitWith {};
     if (life_interrupted) exitWith {};
 };
 
@@ -58,7 +58,7 @@ life_action_inUse = false;
 player playActionNow "stop";
 if (isNull _animalCorpse) exitWith {life_action_inUse = false;};
 if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+if !(isNull objectParent player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
 if ([true,_item,1] call life_fnc_handleInv) then {
     deleteVehicle _animalCorpse;

--- a/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
@@ -49,7 +49,7 @@ for "_i" from 0 to 1 step 0 do {
     if (_cP >= 1) exitWith {};
     if (!alive player) exitWith {};
     if (isNull _animalCorpse) exitWith {};
-    if !(player isEqualTo vehicle player) exitWith {};
+    if !(vehicle player isEqualTo player) exitWith {};
     if (life_interrupted) exitWith {};
 };
 
@@ -58,7 +58,7 @@ life_action_inUse = false;
 player playActionNow "stop";
 if (isNull _animalCorpse) exitWith {life_action_inUse = false;};
 if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
 if ([true,_item,1] call life_fnc_handleInv) then {
     deleteVehicle _animalCorpse;

--- a/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
+++ b/Altis_Life.Altis/core/actions/fn_gutAnimal.sqf
@@ -49,7 +49,7 @@ for "_i" from 0 to 1 step 0 do {
     if (_cP >= 1) exitWith {};
     if (!alive player) exitWith {};
     if (isNull _animalCorpse) exitWith {};
-    if (player != vehicle player) exitWith {};
+    if !(player isEqualTo vehicle player) exitWith {};
     if (life_interrupted) exitWith {};
 };
 
@@ -58,7 +58,7 @@ life_action_inUse = false;
 player playActionNow "stop";
 if (isNull _animalCorpse) exitWith {life_action_inUse = false;};
 if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-if (player != vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
 if ([true,_item,1] call life_fnc_handleInv) then {
     deleteVehicle _animalCorpse;

--- a/Altis_Life.Altis/core/actions/fn_mine.sqf
+++ b/Altis_Life.Altis/core/actions/fn_mine.sqf
@@ -9,7 +9,7 @@
     */
 private ["_maxGather", "_resource", "_amount", "_requiredItem", "_mined"];
 if (life_action_inUse) exitWith {};
-if ((vehicle player) != player) exitWith {};
+if !((vehicle player) isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {
     hint localize "STR_NOTF_isrestrained";
 };

--- a/Altis_Life.Altis/core/actions/fn_mine.sqf
+++ b/Altis_Life.Altis/core/actions/fn_mine.sqf
@@ -9,7 +9,7 @@
     */
 private ["_maxGather", "_resource", "_amount", "_requiredItem", "_mined"];
 if (life_action_inUse) exitWith {};
-if !(vehicle player isEqualTo player) exitWith {};
+if !(isNull objectParent player) exitWith {};
 if (player getVariable "restrained") exitWith {
     hint localize "STR_NOTF_isrestrained";
 };

--- a/Altis_Life.Altis/core/actions/fn_mine.sqf
+++ b/Altis_Life.Altis/core/actions/fn_mine.sqf
@@ -9,7 +9,7 @@
     */
 private ["_maxGather", "_resource", "_amount", "_requiredItem", "_mined"];
 if (life_action_inUse) exitWith {};
-if !((vehicle player) isEqualTo player) exitWith {};
+if !(vehicle player isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {
     hint localize "STR_NOTF_isrestrained";
 };

--- a/Altis_Life.Altis/core/actions/fn_pulloutAction.sqf
+++ b/Altis_Life.Altis/core/actions/fn_pulloutAction.sqf
@@ -10,7 +10,7 @@ private ["_crew"];
 _crew = crew cursorObject;
 
 {
-    if (side _x != west) then {
+    if !(side _x isEqualTo west) then {
         _x setVariable ["transporting",false,true]; _x setVariable ["Escorting",false,true];
         [_x] remoteExecCall ["life_fnc_pulloutVeh",_x];
     };

--- a/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
+++ b/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
@@ -39,7 +39,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
             _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%",_upp];
             if (_cP >= 1) exitWith {};
             if (!alive player) exitWith {};
-            if !(vehicle player isEqualTo player) exitWith {};
+            if !(isNull objectParent player) exitWith {};
             if (life_interrupted) exitWith {};
         };
 
@@ -47,7 +47,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
         "progressBar" cutText ["","PLAIN"];
         player playActionNow "stop";
         if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-        if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+        if !(isNull objectParent player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
         _sideRepairArray = LIFE_SETTINGS(getArray,"vehicle_infiniteRepair");
 

--- a/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
+++ b/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
@@ -39,7 +39,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
             _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%",_upp];
             if (_cP >= 1) exitWith {};
             if (!alive player) exitWith {};
-            if (player != vehicle player) exitWith {};
+            if !(player isEqualTo vehicle player) exitWith {};
             if (life_interrupted) exitWith {};
         };
 
@@ -47,7 +47,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
         "progressBar" cutText ["","PLAIN"];
         player playActionNow "stop";
         if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-        if (player != vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+        if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
         _sideRepairArray = LIFE_SETTINGS(getArray,"vehicle_infiniteRepair");
 

--- a/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
+++ b/Altis_Life.Altis/core/actions/fn_repairTruck.sqf
@@ -39,7 +39,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
             _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%",_upp];
             if (_cP >= 1) exitWith {};
             if (!alive player) exitWith {};
-            if !(player isEqualTo vehicle player) exitWith {};
+            if !(vehicle player isEqualTo player) exitWith {};
             if (life_interrupted) exitWith {};
         };
 
@@ -47,7 +47,7 @@ if ((_veh isKindOf "Car") || (_veh isKindOf "Ship") || (_veh isKindOf "Air")) th
         "progressBar" cutText ["","PLAIN"];
         player playActionNow "stop";
         if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};
-        if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+        if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
         _sideRepairArray = LIFE_SETTINGS(getArray,"vehicle_infiniteRepair");
 

--- a/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
+++ b/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
@@ -11,7 +11,7 @@ _unit = player getVariable ["escortingPlayer",objNull];
 if (isNull _unit) then {_unit = cursorTarget;}; //Emergency fallback.
 if (isNull _unit) exitWith {}; //Target not found even after using cursorTarget.
 if (!(_unit getVariable ["Escorting",false])) exitWith {}; //He's not being Escorted.
-if (side _unit != civilian) exitWith {}; //Not a civ
+if !(side _unit isEqualTo civilian) exitWith {}; //Not a civ
 detach _unit;
 _unit setVariable ["Escorting",false,true];
 player setVariable ["currentlyEscorting",nil];

--- a/Altis_Life.Altis/core/actions/fn_storeVehicle.sqf
+++ b/Altis_Life.Altis/core/actions/fn_storeVehicle.sqf
@@ -7,7 +7,7 @@
     Stores the vehicle in the garage.
 */
 private ["_nearVehicles","_vehicle"];
-if (vehicle player != player) then {
+if !(vehicle player isEqualTo player) then {
     _vehicle = vehicle player;
 } else {
     _nearVehicles = nearestObjects[getPos (_this select 0),["Car","Air","Ship"],30]; //Fetch vehicles within 30m.

--- a/Altis_Life.Altis/core/actions/fn_storeVehicle.sqf
+++ b/Altis_Life.Altis/core/actions/fn_storeVehicle.sqf
@@ -7,7 +7,7 @@
     Stores the vehicle in the garage.
 */
 private ["_nearVehicles","_vehicle"];
-if !(vehicle player isEqualTo player) then {
+if !(isNull objectParent player) then {
     _vehicle = vehicle player;
 } else {
     _nearVehicles = nearestObjects[getPos (_this select 0),["Car","Air","Ship"],30]; //Fetch vehicles within 30m.

--- a/Altis_Life.Altis/core/actions/fn_surrender.sqf
+++ b/Altis_Life.Altis/core/actions/fn_surrender.sqf
@@ -18,7 +18,7 @@ if (player getVariable ["playerSurrender",false]) then {
 
 while {player getVariable ["playerSurrender",false]} do {
     player playMove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
-    if (!alive player || (vehicle player) != player) then { player setVariable ["playerSurrender",false,true]; };
+    if (!alive player || !((vehicle player) isEqualTo player)) then { player setVariable ["playerSurrender",false,true]; };
 };
 
 player playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";

--- a/Altis_Life.Altis/core/actions/fn_surrender.sqf
+++ b/Altis_Life.Altis/core/actions/fn_surrender.sqf
@@ -18,7 +18,7 @@ if (player getVariable ["playerSurrender",false]) then {
 
 while {player getVariable ["playerSurrender",false]} do {
     player playMove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
-    if (!alive player || !((vehicle player) isEqualTo player)) then { player setVariable ["playerSurrender",false,true]; };
+    if (!alive player || !(vehicle player isEqualTo player)) then { player setVariable ["playerSurrender",false,true]; };
 };
 
 player playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";

--- a/Altis_Life.Altis/core/actions/fn_surrender.sqf
+++ b/Altis_Life.Altis/core/actions/fn_surrender.sqf
@@ -18,7 +18,7 @@ if (player getVariable ["playerSurrender",false]) then {
 
 while {player getVariable ["playerSurrender",false]} do {
     player playMove "AmovPercMstpSnonWnonDnon_AmovPercMstpSsurWnonDnon";
-    if (!alive player || !(vehicle player isEqualTo player)) then { player setVariable ["playerSurrender",false,true]; };
+    if (!alive player || !(isNull objectParent player)) then { player setVariable ["playerSurrender",false,true]; };
 };
 
 player playMoveNow "AmovPercMstpSsurWnonDnon_AmovPercMstpSnonWnonDnon";

--- a/Altis_Life.Altis/core/civilian/fn_civMarkers.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_civMarkers.sqf
@@ -15,7 +15,7 @@ for "_i" from 0 to 1 step 0 do {
     {
         _members = units (group player);
         {
-            if (_x != player) then {
+            if !(_x isEqualTo player) then {
                 _marker = createMarkerLocal [format ["%1_marker",_x],visiblePosition _x];
                 _marker setMarkerColorLocal "ColorCivilian";
                 _marker setMarkerTypeLocal "Mil_dot";

--- a/Altis_Life.Altis/core/civilian/fn_jail.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_jail.sqf
@@ -13,7 +13,7 @@ params [
 ];
 
 if (isNull _unit) exitWith {}; //Dafuq?
-if (_unit != player) exitWith {}; //Dafuq?
+if !(_unit isEqualTo player) exitWith {}; //Dafuq?
 if (life_is_arrested) exitWith {}; //Dafuq i'm already arrested
 _illegalItems = LIFE_SETTINGS(getArray,"jail_seize_vItems");
 

--- a/Altis_Life.Altis/core/civilian/fn_knockedOut.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_knockedOut.sqf
@@ -13,7 +13,7 @@ params [
 ];
 
 if (isNull _target) exitWith {};
-if (_target != player) exitWith {};
+if !(_target isEqualTo player) exitWith {};
 if (_who isEqualTo "") exitWith {};
 
 titleText[format [localize "STR_Civ_KnockedOut",_who],"PLAIN"];

--- a/Altis_Life.Altis/core/cop/fn_copMarkers.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copMarkers.sqf
@@ -15,7 +15,7 @@ if (visibleMap) then {
 
     //Create markers
     {
-        if (_x != player) then {
+        if !(_x isEqualTo player) then {
             _marker = createMarkerLocal [format ["%1_marker",_x],visiblePosition _x];
             _marker setMarkerColorLocal "ColorBLUFOR";
             _marker setMarkerTypeLocal "Mil_dot";

--- a/Altis_Life.Altis/core/cop/fn_radar.sqf
+++ b/Altis_Life.Altis/core/cop/fn_radar.sqf
@@ -5,7 +5,7 @@
     Description:
     Looks like weird but radar?
 */
-if (playerSide != west) exitWith {};
+if !(playerSide isEqualTo west) exitWith {};
 private ["_speed","_vehicle"];
 _vehicle = cursorObject;
 _speed = round speed _vehicle;

--- a/Altis_Life.Altis/core/cop/fn_restrain.sqf
+++ b/Altis_Life.Altis/core/cop/fn_restrain.sqf
@@ -55,11 +55,11 @@ while {player getVariable  "restrained"} do {
         detach player;
     };
 
-    if (vehicle player != player && life_disable_getIn) then {
+    if (!(vehicle player isEqualTo player) && life_disable_getIn) then {
         player action["eject",vehicle player];
     };
 
-    if ((vehicle player != player) && (vehicle player != _vehicle)) then {
+    if (!(vehicle player isEqualTo player) && !(vehicle player isEqualTo _vehicle)) then {
         _vehicle = vehicle player;
     };
 
@@ -67,12 +67,12 @@ while {player getVariable  "restrained"} do {
         player moveInCargo _vehicle;
     };
 
-    if ((vehicle player != player) && life_disable_getOut && (driver (vehicle player) isEqualTo player)) then {
+    if (!(vehicle player isEqualTo player) && life_disable_getOut && (driver (vehicle player) isEqualTo player)) then {
         player action["eject",vehicle player];
         player moveInCargo _vehicle;
     };
 
-    if (vehicle player != player && life_disable_getOut) then {
+    if (!(vehicle player isEqualTo player) && life_disable_getOut) then {
         _turrets = [[-1]] + allTurrets _vehicle;
         {
             if (_vehicle turretUnit [_x select 0] isEqualTo player) then {

--- a/Altis_Life.Altis/core/cop/fn_restrain.sqf
+++ b/Altis_Life.Altis/core/cop/fn_restrain.sqf
@@ -55,11 +55,11 @@ while {player getVariable  "restrained"} do {
         detach player;
     };
 
-    if (!(vehicle player isEqualTo player) && life_disable_getIn) then {
+    if (!(isNull objectParent player) && life_disable_getIn) then {
         player action["eject",vehicle player];
     };
 
-    if (!(vehicle player isEqualTo player) && !(vehicle player isEqualTo _vehicle)) then {
+    if (!(isNull objectParent player) && !(vehicle player isEqualTo _vehicle)) then {
         _vehicle = vehicle player;
     };
 
@@ -67,12 +67,12 @@ while {player getVariable  "restrained"} do {
         player moveInCargo _vehicle;
     };
 
-    if (!(vehicle player isEqualTo player) && life_disable_getOut && (driver (vehicle player) isEqualTo player)) then {
+    if (!(isNull objectParent player) && life_disable_getOut && (driver (vehicle player) isEqualTo player)) then {
         player action["eject",vehicle player];
         player moveInCargo _vehicle;
     };
 
-    if (!(vehicle player isEqualTo player) && life_disable_getOut) then {
+    if (!(isNull objectParent player) && life_disable_getOut) then {
         _turrets = [[-1]] + allTurrets _vehicle;
         {
             if (_vehicle turretUnit [_x select 0] isEqualTo player) then {

--- a/Altis_Life.Altis/core/cop/fn_ticketPaid.sqf
+++ b/Altis_Life.Altis/core/cop/fn_ticketPaid.sqf
@@ -11,8 +11,8 @@ params [
     ["_unit",objNull,[objNull]],
     ["_cop",objNull,[objNull]]
 ];
-if (isNull _unit || {_unit != life_ticket_unit}) exitWith {}; //NO
-if (isNull _cop || {_cop != player}) exitWith {}; //Double NO
+if (isNull _unit || {!(_unit isEqualTo life_ticket_unit)}) exitWith {}; //NO
+if (isNull _cop || {!(_cop isEqualTo player)}) exitWith {}; //Double NO
 
 BANK = BANK + _value;
 [1] call SOCK_fnc_updatePartial;

--- a/Altis_Life.Altis/core/fn_initMedic.sqf
+++ b/Altis_Life.Altis/core/fn_initMedic.sqf
@@ -17,7 +17,7 @@ if ((FETCH_CONST(life_medicLevel)) < 1 && (FETCH_CONST(life_adminlevel) isEqualT
 if (LIFE_SETTINGS(getNumber,"restrict_medic_weapons") isEqualTo 1) then {
     [] spawn {
         for "_i" from 0 to 1 step 0 do {
-            waitUntil {sleep 3; currentWeapon player != ""};
+            waitUntil {sleep 3; !(currentWeapon player isEqualTo "")};
             removeAllWeapons player;
         };
     };

--- a/Altis_Life.Altis/core/fn_survival.sqf
+++ b/Altis_Life.Altis/core/fn_survival.sqf
@@ -72,7 +72,7 @@ for "_i" from 0 to 1 step 0 do {
     };
 
     /* Check if the player's state changed? */
-    if (vehicle player != _lastState || {!alive player}) then {
+    if (!(vehicle player isEqualTo _lastState) || {!alive player}) then {
         [] call life_fnc_updateViewDistance;
         _lastState = vehicle player;
     };

--- a/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
@@ -71,7 +71,7 @@ if (_curObject isKindOf "House_F" && {player distance _curObject < 12} || ((near
 };
 
 if (dialog) exitWith {}; //Don't bother when a dialog is open.
-if !(vehicle player isEqualTo player) exitWith {}; //He's in a vehicle, cancel!
+if !(isNull objectParent player) exitWith {}; //He's in a vehicle, cancel!
 life_action_inUse = true;
 
 //Temp fail safe.

--- a/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
@@ -71,7 +71,7 @@ if (_curObject isKindOf "House_F" && {player distance _curObject < 12} || ((near
 };
 
 if (dialog) exitWith {}; //Don't bother when a dialog is open.
-if (vehicle player != player) exitWith {}; //He's in a vehicle, cancel!
+if !(vehicle player isEqualTo player) exitWith {}; //He's in a vehicle, cancel!
 life_action_inUse = true;
 
 //Temp fail safe.

--- a/Altis_Life.Altis/core/functions/fn_fetchCfgDetails.sqf
+++ b/Altis_Life.Altis/core/functions/fn_fetchCfgDetails.sqf
@@ -98,7 +98,7 @@ switch (_section) do
         if (!isNil "_muzzles") then {
             private ["_tmp"];
             {
-                if (_x != "this") then {
+                if !(_x isEqualTo "this") then {
                     _tmp = getArray(_base >> _x >> "magazines"); {
                         _magazines pushBack _x;
                     } forEach (_tmp);

--- a/Altis_Life.Altis/core/functions/fn_fetchCfgDetails.sqf
+++ b/Altis_Life.Altis/core/functions/fn_fetchCfgDetails.sqf
@@ -98,7 +98,7 @@ switch (_section) do
         if (!isNil "_muzzles") then {
             private ["_tmp"];
             {
-                if !(_x isEqualTo "this") then {
+                if (_x != "this") then {
                     _tmp = getArray(_base >> _x >> "magazines"); {
                         _magazines pushBack _x;
                     } forEach (_tmp);

--- a/Altis_Life.Altis/core/functions/fn_giveDiff.sqf
+++ b/Altis_Life.Altis/core/functions/fn_giveDiff.sqf
@@ -8,7 +8,7 @@
 */
 private ["_unit","_item","_val","_from","_bool"];
 _unit = _this select 0;
-if (_unit != player) exitWith {};
+if !(_unit isEqualTo player) exitWith {};
 _item = _this select 1;
 _val = _this select 2;
 _from = _this select 3;

--- a/Altis_Life.Altis/core/functions/fn_handleDamage.sqf
+++ b/Altis_Life.Altis/core/functions/fn_handleDamage.sqf
@@ -26,7 +26,7 @@ if (!isNull _source) then {
                     _distance = 35;
                     if (_projectile == "B_556x45_dual") then {_distance = 100;};
                     if (_unit distance _source < _distance) then {
-                        if !(vehicle player isEqualTo player) then {
+                        if !(isNull objectParent player) then {
                             if (typeOf (vehicle player) == "B_Quadbike_01_F") then {
                                 player action ["Eject",vehicle player];
                                 [_unit,_source] spawn life_fnc_tazed;

--- a/Altis_Life.Altis/core/functions/fn_handleDamage.sqf
+++ b/Altis_Life.Altis/core/functions/fn_handleDamage.sqf
@@ -26,7 +26,7 @@ if (!isNull _source) then {
                     _distance = 35;
                     if (_projectile == "B_556x45_dual") then {_distance = 100;};
                     if (_unit distance _source < _distance) then {
-                        if (vehicle player != player) then {
+                        if !(vehicle player isEqualTo player) then {
                             if (typeOf (vehicle player) == "B_Quadbike_01_F") then {
                                 player action ["Eject",vehicle player];
                                 [_unit,_source] spawn life_fnc_tazed;

--- a/Altis_Life.Altis/core/functions/fn_hudSetup.sqf
+++ b/Altis_Life.Altis/core/functions/fn_hudSetup.sqf
@@ -16,7 +16,7 @@ cutRsc ["playerHUD", "PLAIN", 2, false];
     private ["_dam"];
     for "_i" from 0 to 1 step 0 do {
         _dam = damage player;
-        waitUntil {(damage player) != _dam};
+        waitUntil {!((damage player) isEqualTo _dam)};
         [] call life_fnc_hudUpdate;
     };
 };

--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -134,7 +134,7 @@ switch (_code) do {
     //T Key (Trunk)
     case 20: {
         if (!_alt && !_ctrlKey && !dialog && {!life_action_inUse}) then {
-            if (vehicle player != player && alive vehicle player) then {
+            if (!(vehicle player isEqualTo player) && alive vehicle player) then {
                 if ((vehicle player) in life_vehicles) then {
                     [vehicle player] spawn life_fnc_openInventory;
                 };
@@ -164,7 +164,7 @@ switch (_code) do {
     case 38: {
         //If cop run checks for turning lights on.
         if (_shift && playerSide in [west,independent]) then {
-            if (vehicle player != player && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
+            if (!(vehicle player isEqualTo player) && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
                 if (!isNil {vehicle player getVariable "lights"}) then {
                     if (playerSide isEqualTo west) then {
                         [vehicle player] call life_fnc_sirenLights;
@@ -215,7 +215,7 @@ switch (_code) do {
     //O Key
     case 24: {
         if (_shift) then {
-            if (soundVolume != 1) then {
+            if !(soundVolume isEqualTo 1) then {
                 1 fadeSound 1;
                 systemChat localize "STR_MISC_soundnormal";
             } else {

--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -134,7 +134,7 @@ switch (_code) do {
     //T Key (Trunk)
     case 20: {
         if (!_alt && !_ctrlKey && !dialog && {!life_action_inUse}) then {
-            if (!(vehicle player isEqualTo player) && alive vehicle player) then {
+            if (!(isNull objectParent player) && alive vehicle player) then {
                 if ((vehicle player) in life_vehicles) then {
                     [vehicle player] spawn life_fnc_openInventory;
                 };
@@ -164,7 +164,7 @@ switch (_code) do {
     case 38: {
         //If cop run checks for turning lights on.
         if (_shift && playerSide in [west,independent]) then {
-            if (!(vehicle player isEqualTo player) && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
+            if (!(isNull objectParent player) && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
                 if (!isNil {vehicle player getVariable "lights"}) then {
                     if (playerSide isEqualTo west) then {
                         [vehicle player] call life_fnc_sirenLights;

--- a/Altis_Life.Altis/core/functions/fn_nearUnits.sqf
+++ b/Altis_Life.Altis/core/functions/fn_nearUnits.sqf
@@ -18,5 +18,5 @@ _ret = false;
 //Error check
 if (_faction isEqualTo sideUnknown) exitWith {_ret};
 
-_ret = {_x != player && side _x isEqualTo _faction && alive _x && _position distance _x < _radius} count playableUnits > 0;
+_ret = {!(_x isEqualTo player) && side _x isEqualTo _faction && alive _x && _position distance _x < _radius} count playableUnits > 0;
 _ret;

--- a/Altis_Life.Altis/core/functions/fn_numberText.sqf
+++ b/Altis_Life.Altis/core/functions/fn_numberText.sqf
@@ -23,6 +23,6 @@ _modBase = _digitsCount % _mod;
 _numberText = "";
 {
     _numberText = _numberText + str _x;
-    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && _foreachindex != _digitsCount) then {_numberText = _numberText + ",";};
+    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && !(_foreachindex isEqualTo _digitsCount)) then {_numberText = _numberText + ",";};
 } forEach _digits;
 _numberText

--- a/Altis_Life.Altis/core/functions/fn_receiveItem.sqf
+++ b/Altis_Life.Altis/core/functions/fn_receiveItem.sqf
@@ -8,7 +8,7 @@
 */
 private ["_unit","_val","_item","_from","_diff"];
 _unit = _this select 0;
-if (_unit != player) exitWith {};
+if !(_unit isEqualTo player) exitWith {};
 _val = _this select 1;
 _item = _this select 2;
 _from = _this select 3;

--- a/Altis_Life.Altis/core/functions/fn_receiveMoney.sqf
+++ b/Altis_Life.Altis/core/functions/fn_receiveMoney.sqf
@@ -14,7 +14,7 @@ params [
 ];
 
 if (isNull _unit || isNull _from || _val isEqualTo "") exitWith {};
-if (player != _unit) exitWith {};
+if !(player isEqualTo _unit) exitWith {};
 if (!([_val] call TON_fnc_isnumber)) exitWith {};
 if (_unit == _from) exitWith {}; //Bad boy, trying to exploit his way to riches.
 

--- a/Altis_Life.Altis/core/gangs/fn_gangMenu.sqf
+++ b/Altis_Life.Altis/core/gangs/fn_gangMenu.sqf
@@ -19,7 +19,7 @@ _gangName = group player getVariable "gang_name";
 _gangBank = GANG_FUNDS;
 _gangMax = group player getVariable "gang_maxMembers";
 
-if (_ownerID != getPlayerUID player) then {
+if !(_ownerID isEqualTo getPlayerUID player) then {
     (CONTROL(2620,2622)) ctrlEnable false; //Upgrade
     (CONTROL(2620,2624)) ctrlEnable false; // Kick
     (CONTROL(2620,2625)) ctrlEnable false; //Set New Leader
@@ -48,7 +48,7 @@ _allUnits = playableUnits;
 
 //Clear out the list..
 {
-    if (_x in _grpMembers || side _x != civilian && isNil {(group _x) getVariable "gang_id"}) then {
+    if (_x in _grpMembers || !(side _x isEqualTo civilian) && isNil {(group _x) getVariable "gang_id"}) then {
         _allUnits deleteAt _forEachIndex;
     };
 } forEach _allUnits;

--- a/Altis_Life.Altis/core/gangs/fn_initGang.sqf
+++ b/Altis_Life.Altis/core/gangs/fn_initGang.sqf
@@ -7,7 +7,7 @@
     Main initialization for gangs.
 */
 private ["_exitLoop","_group","_wait"];
-if (playerSide != civilian) exitWith {}; //What in the hell?
+if !(playerSide isEqualTo civilian) exitWith {}; //What in the hell?
 [player] join (createGroup civilian);
 if (count life_gangData isEqualTo 0) exitWith {}; //Dafuq?
 

--- a/Altis_Life.Altis/core/housing/fn_garageRefund.sqf
+++ b/Altis_Life.Altis/core/housing/fn_garageRefund.sqf
@@ -8,6 +8,6 @@
 */
 _price = _this select 0;
 _unit = _this select 1;
-if (_unit != player) exitWith {};
+if !(_unit isEqualTo player) exitWith {};
 BANK = BANK + _price;
 [1] call SOCK_fnc_updatePartial;

--- a/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
+++ b/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
@@ -51,12 +51,12 @@ if (_action) then {
         publicVariableServer "advanced_log";
     };
 
-    if (_index != -1) then {
+    if !(_index isEqualTo -1) then {
         life_vehicles deleteAt _index;
     };
 
     _index = [str(getPosATL _house),life_houses] call TON_fnc_index;
-    if (_index != -1) then {
+    if !(_index isEqualTo -1) then {
         life_houses deleteAt _index;
     };
     _numOfDoors = FETCH_CONFIG2(getNumber,"CfgVehicles",(typeOf _house), "numberOfDoors");

--- a/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
+++ b/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
@@ -12,7 +12,7 @@ life_interrupted = false;
 if (life_inv_fuelEmpty isEqualTo 0) exitWith {};
 if (count(nearestObjects [player,["Land_FuelStation_Feed_F","Land_fs_feed_F"],3.5]) isEqualTo 0) exitWith { hint localize "STR_ISTR_Jerry_Distance";};
 if (life_action_inUse) exitWith {};
-if !((vehicle player) isEqualTo player) exitWith {};
+if !(vehicle player isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 _fuelCost = LIFE_SETTINGS(getNumber,"fuelCan_refuel");

--- a/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
+++ b/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
@@ -12,7 +12,7 @@ life_interrupted = false;
 if (life_inv_fuelEmpty isEqualTo 0) exitWith {};
 if (count(nearestObjects [player,["Land_FuelStation_Feed_F","Land_fs_feed_F"],3.5]) isEqualTo 0) exitWith { hint localize "STR_ISTR_Jerry_Distance";};
 if (life_action_inUse) exitWith {};
-if ((vehicle player) != player) exitWith {};
+if !((vehicle player) isEqualTo player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 _fuelCost = LIFE_SETTINGS(getNumber,"fuelCan_refuel");

--- a/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
+++ b/Altis_Life.Altis/core/items/fn_jerryCanRefuel.sqf
@@ -12,7 +12,7 @@ life_interrupted = false;
 if (life_inv_fuelEmpty isEqualTo 0) exitWith {};
 if (count(nearestObjects [player,["Land_FuelStation_Feed_F","Land_fs_feed_F"],3.5]) isEqualTo 0) exitWith { hint localize "STR_ISTR_Jerry_Distance";};
 if (life_action_inUse) exitWith {};
-if !(vehicle player isEqualTo player) exitWith {};
+if !(isNull objectParent player) exitWith {};
 if (player getVariable "restrained") exitWith {hint localize "STR_NOTF_isrestrained";};
 if (player getVariable "playerSurrender") exitWith {hint localize "STR_NOTF_surrender";};
 _fuelCost = LIFE_SETTINGS(getNumber,"fuelCan_refuel");

--- a/Altis_Life.Altis/core/medical/fn_medicMarkers.sqf
+++ b/Altis_Life.Altis/core/medical/fn_medicMarkers.sqf
@@ -23,7 +23,7 @@ if (visibleMap) then {
     } forEach allDeadMen;
 
     {
-        if (_x != player) then {
+        if !(_x isEqualTo player) then {
             _markerss = createMarkerLocal [format ["%1_marker",_x],visiblePosition _x];
             _markerss setMarkerColorLocal "ColorIndependent";
             _markerss setMarkerTypeLocal "Mil_dot";

--- a/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
@@ -80,7 +80,7 @@ _unit spawn {
 };
 
 //Make the killer wanted
-if (!isNull _killer && {_killer != _unit} && {side _killer != west} && {alive _killer}) then {
+if (!isNull _killer && {!(_killer isEqualTo _unit)} && {!(side _killer isEqualTo west)} && {alive _killer}) then {
     if (vehicle _killer isKindOf "LandVehicle") then {
 
         if (life_HC_isActive) then {
@@ -117,7 +117,7 @@ if (LIFE_SETTINGS(getNumber,"drop_weapons_onDeath") isEqualTo 0) then {
 
 
 //Killed by cop stuff...
-if (side _killer isEqualTo west && playerSide != west) then {
+if (side _killer isEqualTo west && !(playerSide isEqualTo west)) then {
     life_copRecieve = _killer;
     //Did I rob the federal reserve?
     if (!life_use_atm && {CASH > 0}) then {
@@ -126,7 +126,7 @@ if (side _killer isEqualTo west && playerSide != west) then {
     };
 };
 
-if (!isNull _killer && {_killer != _unit}) then {
+if (!isNull _killer && {!(_killer isEqualTo _unit)}) then {
     life_removeWanted = true;
 };
 

--- a/Altis_Life.Altis/core/medical/fn_requestMedic.sqf
+++ b/Altis_Life.Altis/core/medical/fn_requestMedic.sqf
@@ -7,7 +7,7 @@
     N/A
 */
 private "_medicsOnline";
-_medicsOnline = {_x != player && {side _x isEqualTo independent} && {alive _x}} count playableUnits > 0; //Check if medics (indep) are in the room.
+_medicsOnline = {!(_x isEqualTo player) && {side _x isEqualTo independent} && {alive _x}} count playableUnits > 0; //Check if medics (indep) are in the room.
 
 life_corpse setVariable ["Revive",false,true]; //Set the corpse to a revivable state.
 if (_medicsOnline) then {

--- a/Altis_Life.Altis/core/pmenu/fn_cellphone.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_cellphone.sqf
@@ -21,7 +21,7 @@ if (FETCH_CONST(life_adminlevel) < 1) then {
     ctrlShow[3021,false];
 };
 {
-    if (alive _x && _x != player) then {
+    if (alive _x && !(_x isEqualTo player)) then {
         switch (side _x) do {
             case west: {_type = "Cop"};
             case civilian: {_type = "Civ"};

--- a/Altis_Life.Altis/core/pmenu/fn_cellphone.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_cellphone.sqf
@@ -22,10 +22,10 @@ if (FETCH_CONST(life_adminlevel) < 1) then {
 };
 {
     if (alive _x && !(_x isEqualTo player)) then {
-        switch (side _x) do {
-            case west: {_type = "Cop"};
-            case civilian: {_type = "Civ"};
-            case independent: {_type = "Med"};
+        _type = switch (side _x) do {
+            case west: {"Cop"};
+            case civilian: {"Civ"};
+            case independent: {"Med"};
         };
         _units lbAdd format ["%1 (%2)",_x getVariable ["realname",name _x],_type];
         _units lbSetData [(lbSize _units)-1,str(_x)];

--- a/Altis_Life.Altis/core/pmenu/fn_keyMenu.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_keyMenu.sqf
@@ -41,7 +41,7 @@ for "_i" from 0 to (count life_vehicles)-1 do {
 };
 
 {
-    if (!isNull _x && alive _x && player distance _x < 20 && _x != player) then {
+    if (!isNull _x && alive _x && player distance _x < 20 && !(_x isEqualTo player)) then {
         _plist lbAdd format ["%1 - %2",_x getVariable ["realname",name _x], side _x];
         _plist lbSetData [(lbSize _plist)-1,str(_x)];
     };

--- a/Altis_Life.Altis/core/pmenu/fn_p_updateMenu.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_p_updateMenu.sqf
@@ -29,7 +29,7 @@ lbClear _near_i;
 _near_units = [];
 { if (player distance _x < 10) then {_near_units pushBack _x};} forEach playableUnits;
 {
-    if (!isNull _x && alive _x && player distance _x < 10 && _x != player) then {
+    if (!isNull _x && alive _x && player distance _x < 10 && !(_x isEqualTo player)) then {
         _near lbAdd format ["%1 - %2",_x getVariable ["realname",name _x], side _x];
         _near lbSetData [(lbSize _near)-1,str(_x)];
         _near_i lbAdd format ["%1 - %2",_x getVariable ["realname",name _x], side _x];

--- a/Altis_Life.Altis/core/pmenu/fn_pardon.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_pardon.sqf
@@ -8,7 +8,7 @@
 */
 private ["_display","_list"];
 disableSerialization;
-if (playerSide != west) exitWith {};
+if !(playerSide isEqualTo west) exitWith {};
 
 _display = findDisplay 2400;
 _list = _display displayCtrl 2402;

--- a/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
@@ -16,7 +16,7 @@ if (_data isEqualTo "") exitWith {hint localize "STR_NOTF_didNotSelectToRemove";
 if (!([_value] call TON_fnc_isnumber)) exitWith {hint localize "STR_NOTF_notNumberFormat";};
 if (parseNumber(_value) <= 0) exitWith {hint localize "STR_NOTF_enterAmountRemove";};
 if (ITEM_ILLEGAL(_data) isEqualTo 1 && ([west,visiblePosition player,100] call life_fnc_nearUnits)) exitWith {titleText[localize "STR_NOTF_illegalItemCannotDispose","PLAIN"]};
-if (player != vehicle player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
+if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
 if (!([false,_data,(parseNumber _value)] call life_fnc_handleInv)) exitWith {hint localize "STR_NOTF_couldNotRemoveThatMuch";};
 
 hint format [localize "STR_NOTF_removedFromInventory",(parseNumber _value),(localize ITEM_NAME(_data))];

--- a/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
@@ -16,7 +16,7 @@ if (_data isEqualTo "") exitWith {hint localize "STR_NOTF_didNotSelectToRemove";
 if (!([_value] call TON_fnc_isnumber)) exitWith {hint localize "STR_NOTF_notNumberFormat";};
 if (parseNumber(_value) <= 0) exitWith {hint localize "STR_NOTF_enterAmountRemove";};
 if (ITEM_ILLEGAL(_data) isEqualTo 1 && ([west,visiblePosition player,100] call life_fnc_nearUnits)) exitWith {titleText[localize "STR_NOTF_illegalItemCannotDispose","PLAIN"]};
-if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
+if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
 if (!([false,_data,(parseNumber _value)] call life_fnc_handleInv)) exitWith {hint localize "STR_NOTF_couldNotRemoveThatMuch";};
 
 hint format [localize "STR_NOTF_removedFromInventory",(parseNumber _value),(localize ITEM_NAME(_data))];

--- a/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_removeItem.sqf
@@ -16,7 +16,7 @@ if (_data isEqualTo "") exitWith {hint localize "STR_NOTF_didNotSelectToRemove";
 if (!([_value] call TON_fnc_isnumber)) exitWith {hint localize "STR_NOTF_notNumberFormat";};
 if (parseNumber(_value) <= 0) exitWith {hint localize "STR_NOTF_enterAmountRemove";};
 if (ITEM_ILLEGAL(_data) isEqualTo 1 && ([west,visiblePosition player,100] call life_fnc_nearUnits)) exitWith {titleText[localize "STR_NOTF_illegalItemCannotDispose","PLAIN"]};
-if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
+if !(isNull objectParent player) exitWith {titleText[localize "STR_NOTF_cannotRemoveInVeh","PLAIN"]};
 if (!([false,_data,(parseNumber _value)] call life_fnc_handleInv)) exitWith {hint localize "STR_NOTF_couldNotRemoveThatMuch";};
 
 hint format [localize "STR_NOTF_removedFromInventory",(parseNumber _value),(localize ITEM_NAME(_data))];

--- a/Altis_Life.Altis/core/pmenu/fn_useItem.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_useItem.sqf
@@ -62,7 +62,7 @@ switch (true) do {
     };
 
     case (_item isEqualTo "fuelFull"): {
-        if (vehicle player != player) exitWith {hint localize "STR_ISTR_RefuelInVehicle"};
+        if !(vehicle player isEqualTo player) exitWith {hint localize "STR_ISTR_RefuelInVehicle"};
         [] spawn life_fnc_jerryRefuel;
         closeDialog 0;
     };

--- a/Altis_Life.Altis/core/pmenu/fn_useItem.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_useItem.sqf
@@ -62,7 +62,7 @@ switch (true) do {
     };
 
     case (_item isEqualTo "fuelFull"): {
-        if !(vehicle player isEqualTo player) exitWith {hint localize "STR_ISTR_RefuelInVehicle"};
+        if !(isNull objectParent player) exitWith {hint localize "STR_ISTR_RefuelInVehicle"};
         [] spawn life_fnc_jerryRefuel;
         closeDialog 0;
     };

--- a/Altis_Life.Altis/core/session/fn_requestReceived.sqf
+++ b/Altis_Life.Altis/core/session/fn_requestReceived.sqf
@@ -78,7 +78,7 @@ switch (playerSide) do {
             life_is_alive = _this select 10;
             life_civ_position = _this select 11;
             if (life_is_alive) then {
-                if (count life_civ_position != 3) then {diag_log format ["[requestReceived] Bad position received. Data: %1",life_civ_position];life_is_alive =false;};
+                if !(count life_civ_position isEqualTo 3) then {diag_log format ["[requestReceived] Bad position received. Data: %1",life_civ_position];life_is_alive =false;};
                 if (life_civ_position distance (getMarkerPos "respawn_civilian") < 300) then {life_is_alive = false;};
             };
         };

--- a/Altis_Life.Altis/core/shops/fn_chopShopMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_chopShopMenu.sqf
@@ -8,7 +8,7 @@
 */
 private ["_control","_price","_nearVehicles","_chopMultiplier","_chopable","_nearUnits"];
 if (life_action_inUse) exitWith {hint localize "STR_NOTF_ActionInProc"};
-if (playerSide != civilian) exitWith {hint localize "STR_NOTF_notAllowed"};
+if !(playerSide isEqualTo civilian) exitWith {hint localize "STR_NOTF_notAllowed"};
 disableSerialization;
 _chopable = LIFE_SETTINGS(getArray,"chopShop_vehicles");
 _nearVehicles = nearestObjects [getMarkerPos (_this select 3),_chopable,25];

--- a/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
@@ -11,7 +11,7 @@
 params ["","","",["_shop","",[""]]];
 
 if (_shop isEqualTo "") exitWith {};
-if !(player isEqualTo vehicle player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
 /* License check & config validation */
 if !(isClass(missionConfigFile >> "Clothing" >> _shop)) exitWith {}; //Bad config entry.

--- a/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
@@ -11,7 +11,7 @@
 params ["","","",["_shop","",[""]]];
 
 if (_shop isEqualTo "") exitWith {};
-if !(vehicle player isEqualTo player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
+if !(isNull objectParent player) exitWith {titleText[localize "STR_NOTF_ActionInVehicle","PLAIN"];};
 
 /* License check & config validation */
 if !(isClass(missionConfigFile >> "Clothing" >> _shop)) exitWith {}; //Bad config entry.

--- a/Altis_Life.Altis/core/shops/fn_vehicleShopLBChange.sqf
+++ b/Altis_Life.Altis/core/shops/fn_vehicleShopLBChange.sqf
@@ -103,7 +103,7 @@ if (_className in (LIFE_SETTINGS(getArray,"vehicleShop_rentalOnly"))) then {
     };
 };
 
-if ((lbSize _ctrl)-1 != -1) then {
+if !((lbSize _ctrl)-1 isEqualTo -1) then {
     ctrlShow[2304,true];
 } else {
     ctrlShow[2304,false];

--- a/Altis_Life.Altis/core/vehicle/fn_fuelRefuelCar.sqf
+++ b/Altis_Life.Altis/core/vehicle/fn_fuelRefuelCar.sqf
@@ -28,7 +28,7 @@ if (_car isKindOf "I_Truck_02_covered_F" || _car isKindOf "I_Truck_02_transport_
 _fueltoput= ((SliderPosition 20901)-(floor(_fuelnow * _fueltank)));
 _setfuell = _fuelnow + (_fueltoput/_fueltank);
 _timer = ((_fueltoput * .25)/100);
-if (_car distance player > 10 && !(vehicle player isEqualTo player)) exitWith {
+if (_car distance player > 10 && !(isNull objectParent player)) exitWith {
     hint localize "STR_Distance_Vehicle_Pump";
     vehiclefuelList = [];
     life_action_inUse = false;
@@ -55,7 +55,7 @@ if ((BANK - (_fueltoput * life_fuelPrices))> 0)then {
         _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%","Refuel:"];
         if (_cP >= 1) exitWith {};
         if (player distance _car > 10) exitWith {};
-        if !(vehicle player isEqualTo player) exitWith {};
+        if !(isNull objectParent player) exitWith {};
         if !((BANK - round(0.01 * _totalcost))> 0) exitWith {};
         BANK = BANK - round((0.01 * _totalcost));
         _tp = _tp +1;
@@ -65,7 +65,7 @@ if ((BANK - (_fueltoput * life_fuelPrices))> 0)then {
         };
     };
     "progressBar" cutText ["","PLAIN"];
-    if (_car distance player > 10 || !(vehicle player isEqualTo player)) then {
+    if (_car distance player > 10 || !(isNull objectParent player)) then {
         hint localize "STR_Distance_Vehicle_Pump";
         vehiclefuelList = [];
         life_is_processing = false;

--- a/Altis_Life.Altis/core/vehicle/fn_fuelRefuelCar.sqf
+++ b/Altis_Life.Altis/core/vehicle/fn_fuelRefuelCar.sqf
@@ -28,7 +28,7 @@ if (_car isKindOf "I_Truck_02_covered_F" || _car isKindOf "I_Truck_02_transport_
 _fueltoput= ((SliderPosition 20901)-(floor(_fuelnow * _fueltank)));
 _setfuell = _fuelnow + (_fueltoput/_fueltank);
 _timer = ((_fueltoput * .25)/100);
-if (_car distance player > 10 && vehicle player != player) exitWith {
+if (_car distance player > 10 && !(vehicle player isEqualTo player)) exitWith {
     hint localize "STR_Distance_Vehicle_Pump";
     vehiclefuelList = [];
     life_action_inUse = false;
@@ -55,7 +55,7 @@ if ((BANK - (_fueltoput * life_fuelPrices))> 0)then {
         _pgText ctrlSetText format ["%3 (%1%2)...",round(_cP * 100),"%","Refuel:"];
         if (_cP >= 1) exitWith {};
         if (player distance _car > 10) exitWith {};
-        if (vehicle player != player) exitWith {};
+        if !(vehicle player isEqualTo player) exitWith {};
         if !((BANK - round(0.01 * _totalcost))> 0) exitWith {};
         BANK = BANK - round((0.01 * _totalcost));
         _tp = _tp +1;
@@ -65,7 +65,7 @@ if ((BANK - (_fueltoput * life_fuelPrices))> 0)then {
         };
     };
     "progressBar" cutText ["","PLAIN"];
-    if (_car distance player > 10 || vehicle player != player) then {
+    if (_car distance player > 10 || !(vehicle player isEqualTo player)) then {
         hint localize "STR_Distance_Vehicle_Pump";
         vehiclefuelList = [];
         life_is_processing = false;

--- a/Altis_Life.Altis/dialog/function/fn_safeOpen.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_safeOpen.sqf
@@ -9,7 +9,7 @@
 if (dialog) exitWith {}; //A dialog is already open.
 life_safeObj = param [0,objNull,[objNull]];
 if (isNull life_safeObj) exitWith {};
-if (playerSide != civilian) exitWith {};
+if !(playerSide isEqualTo civilian) exitWith {};
 if ((life_safeObj getVariable ["safe",-1]) < 1) exitWith {hint localize "STR_Civ_VaultEmpty";};
 if (life_safeObj getVariable ["inUse",false]) exitWith {hint localize "STR_Civ_VaultInUse"};
 if (west countSide playableUnits < (LIFE_SETTINGS(getNumber,"minimum_cops"))) exitWith {

--- a/life_hc/MySQL/Gangs/fn_queryPlayerGang.sqf
+++ b/life_hc/MySQL/Gangs/fn_queryPlayerGang.sqf
@@ -13,7 +13,7 @@ _query = format ["SELECT id, owner, name, maxmembers, bank, members FROM gangs W
 
 _queryResult = [_query,2] call HC_fnc_asyncCall;
 
-if (count _queryResult != 0) then {
+if !(count _queryResult isEqualTo 0) then {
     _tmp = [_queryResult select 5] call HC_fnc_mresToArray;
     if (_tmp isEqualType "") then {_tmp = call compile format ["%1",_tmp];};
     _queryResult set[5, _tmp];

--- a/life_hc/MySQL/General/fn_huntingZone.sqf
+++ b/life_hc/MySQL/General/fn_huntingZone.sqf
@@ -23,7 +23,7 @@ _radius = (getMarkerSize _zoneName) select 0;
 _dist = _radius + 100;
 _zone = getMarkerPos _zoneName;
 
-if (!isNil "animals" && {count animals != 0}) then {
+if (!isNil "animals" && {!(count animals isEqualTo 0)}) then {
     _maxAnimals = _maxAnimals - count(animals);
 } else {
     animals = [];

--- a/life_hc/MySQL/General/fn_insertRequest.sqf
+++ b/life_hc/MySQL/General/fn_insertRequest.sqf
@@ -29,7 +29,7 @@ _queryResult = [_query,2] call HC_fnc_asyncCall;
 
 //Double check to make sure the client isn't in the database...
 if (_queryResult isEqualType "") exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",_returnToSender];}; //There was an entry!
-if (count _queryResult != 0) exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",_returnToSender];};
+if !(count _queryResult isEqualTo 0) exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",_returnToSender];};
 
 //Clense and prepare some information.
 _name = [_name] call HC_fnc_mresString; //Clense the name of bad chars.

--- a/life_hc/MySQL/General/fn_mresArray.sqf
+++ b/life_hc/MySQL/General/fn_mresArray.sqf
@@ -15,7 +15,7 @@ _array = toArray(_array);
 for "_i" from 0 to (count _array)-1 do
 {
     _sel = _array select _i;
-    if ((_i != 0 && _i != ((count _array)-1))) then
+    if (!(_i isEqualTo 0) && !(_i isEqualTo ((count _array)-1))) then
     {
         if (_sel isEqualTo 34) then
         {

--- a/life_hc/MySQL/General/fn_numberSafe.sqf
+++ b/life_hc/MySQL/General/fn_numberSafe.sqf
@@ -23,6 +23,6 @@ _modBase = _digitsCount % _mod;
 _numberText = "";
 {
     _numberText = _numberText + str _x;
-    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && _foreachindex != _digitsCount) then {_numberText = _numberText + "";};
+    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && !(_foreachindex isEqualTo _digitsCount)) then {_numberText = _numberText + "";};
 } forEach _digits;
 _numberText

--- a/life_hc/MySQL/General/fn_queryRequest.sqf
+++ b/life_hc/MySQL/General/fn_queryRequest.sqf
@@ -78,7 +78,7 @@ switch (_side) do {
         _new = [(_queryResult select 11)] call HC_fnc_mresToArray;
         if (_new isEqualType "") then {_new = call compile format ["%1", _new];};
         _index = TON_fnc_playtime_values_request find [_uid, _new];
-        if (_index != -1) then {
+        if !(_index isEqualTo -1) then {
             TON_fnc_playtime_values_request set[_index,-1];
             TON_fnc_playtime_values_request = TON_fnc_playtime_values_request - [-1];
             TON_fnc_playtime_values_request pushBack [_uid, _new];
@@ -107,7 +107,7 @@ switch (_side) do {
         _new = [(_queryResult select 12)] call HC_fnc_mresToArray;
         if (_new isEqualType "") then {_new = call compile format ["%1", _new];};
         _index = TON_fnc_playtime_values_request find [_uid, _new];
-        if (_index != -1) then {
+        if !(_index isEqualTo -1) then {
             TON_fnc_playtime_values_request set[_index,-1];
             TON_fnc_playtime_values_request = TON_fnc_playtime_values_request - [-1];
             TON_fnc_playtime_values_request pushBack [_uid, _new];
@@ -135,7 +135,7 @@ switch (_side) do {
         _new = [(_queryResult select 10)] call HC_fnc_mresToArray;
         if (_new isEqualType "") then {_new = call compile format ["%1", _new];};
         _index = TON_fnc_playtime_values_request find [_uid, _new];
-        if (_index != -1) then {
+        if !(_index isEqualTo -1) then {
             TON_fnc_playtime_values_request set[_index,-1];
             TON_fnc_playtime_values_request = TON_fnc_playtime_values_request - [-1];
             TON_fnc_playtime_values_request pushBack [_uid, _new];

--- a/life_hc/MySQL/Vehicles/fn_vehicleStore.sqf
+++ b/life_hc/MySQL/Vehicles/fn_vehicleStore.sqf
@@ -68,7 +68,7 @@ if (_vInfo isEqualTo []) exitWith {
     _ownerID publicVariableClient "life_garage_store";
 };
 
-if (_uid != getPlayerUID _unit) exitWith {
+if !(_uid isEqualTo getPlayerUID _unit) exitWith {
     [1,"STR_Garage_Store_NoOwnership",true] remoteExecCall ["life_fnc_broadcast",_ownerID];
     life_garage_store = false;
     _ownerID publicVariableClient "life_garage_store";

--- a/life_hc/MySQL/WantedSystem/fn_wantedAdd.sqf
+++ b/life_hc/MySQL/WantedSystem/fn_wantedAdd.sqf
@@ -70,7 +70,7 @@ switch (_type) do
 
 if (_type isEqualTo []) exitWith {}; //Not our information being passed...
 //Is there a custom bounty being sent? Set that as the pricing.
-if (_customBounty != -1) then {_type set[1,_customBounty];};
+if !(_customBounty isEqualTo -1) then {_type set[1,_customBounty];};
 //Search the wanted list to make sure they are not on it.
 
 _query = format ["SELECT wantedID FROM wanted WHERE wantedID='%1'",_uid];
@@ -78,7 +78,7 @@ _queryResult = [_query,2,true] call HC_fnc_asyncCall;
 _val = [_type select 1] call HC_fnc_numberSafe;
 _number = _type select 0;
 
-if (count _queryResult != 0) then
+if !(count _queryResult isEqualTo 0) then
 {
     _crime = format ["SELECT wantedCrimes, wantedBounty FROM wanted WHERE wantedID='%1'",_uid];
     _crimeresult = [_crime,2] call HC_fnc_asyncCall;

--- a/life_hc/MySQL/WantedSystem/fn_wantedAdd.sqf
+++ b/life_hc/MySQL/WantedSystem/fn_wantedAdd.sqf
@@ -10,7 +10,7 @@
     Description:
     Adds or appends a unit to the wanted list.
 */
-private ["_uid","_type","_index","_data","_crimes","_val","_customBounty","_name","_pastCrimes","_query","_queryResult"];
+private ["_uid","_type","_index","_data","_crime","_val","_customBounty","_name","_pastCrimes","_query","_queryResult"];
 _uid = [_this,0,"",[""]] call BIS_fnc_param;
 _name = [_this,1,"",[""]] call BIS_fnc_param;
 _type = [_this,2,"",[""]] call BIS_fnc_param;
@@ -90,8 +90,8 @@ if !(count _queryResult isEqualTo 0) then
     _query = format ["UPDATE wanted SET wantedCrimes = '%1', wantedBounty = wantedBounty + '%2', active = '1' WHERE wantedID='%3'",_pastCrimes,_val,_uid];
     [_query,1] call HC_fnc_asyncCall;
 } else {
-    _crimes = [_type select 0];
-    _crimes = [_crimes] call HC_fnc_mresArray;
-    _query = format ["INSERT INTO wanted (wantedID, wantedName, wantedCrimes, wantedBounty, active) VALUES('%1', '%2', '%3', '%4', '1')",_uid,_name,_crimes,_val];
+    _crime = [_type select 0];
+    _crime = [_crime] call HC_fnc_mresArray;
+    _query = format ["INSERT INTO wanted (wantedID, wantedName, wantedCrimes, wantedBounty, active) VALUES('%1', '%2', '%3', '%4', '1')",_uid,_name,_crime,_val];
     [_query,1] call HC_fnc_asyncCall;
 };

--- a/life_hc/MySQL/WantedSystem/fn_wantedBounty.sqf
+++ b/life_hc/MySQL/WantedSystem/fn_wantedBounty.sqf
@@ -20,10 +20,10 @@ if (isNull _civ || isNull _cop) exitWith {};
 _query = format ["SELECT wantedID, wantedName, wantedCrimes, wantedBounty FROM wanted WHERE active='1' AND wantedID='%1'",_uid];
 _queryResult = [_query,2] call HC_fnc_asyncCall;
 
-if (count _queryResult != 0) then
+if !(count _queryResult isEqualTo 0) then
 {
     _amount = _queryResult select 3;
-    if (_amount != 0) then {
+    if !(_amount isEqualTo 0) then {
         if (_half) then {
             [((_amount) / 2),_amount] remoteExecCall ["life_fnc_bountyReceive",_cop];
         } else {

--- a/life_hc/MySQL/WantedSystem/fn_wantedProfUpdate.sqf
+++ b/life_hc/MySQL/WantedSystem/fn_wantedProfUpdate.sqf
@@ -21,7 +21,7 @@ _wantedQuery = [_wantedCheck,2] call HC_fnc_asyncCall;
 if (_wantedQuery isEqualTo []) exitWith {};
 _wantedQuery = call compile format ["%1",_wantedQuery];
 
-if (_name != (_wantedQuery select 0)) then {
+if !(_name isEqualTo (_wantedQuery select 0)) then {
     _query = format ["UPDATE wanted SET wantedName='%1' WHERE wantedID='%2'",_name,_uid];
     [_query,2] call HC_fnc_asyncCall;
 };

--- a/life_server/Functions/Gangs/fn_queryPlayerGang.sqf
+++ b/life_server/Functions/Gangs/fn_queryPlayerGang.sqf
@@ -11,7 +11,7 @@ _query = format ["SELECT id, owner, name, maxmembers, bank, members FROM gangs W
 
 _queryResult = [_query,2] call DB_fnc_asyncCall;
 
-if (count _queryResult != 0) then {
+if !(count _queryResult isEqualTo 0) then {
     _tmp = [_queryResult select 5] call DB_fnc_mresToArray;
     if (_tmp isEqualType "") then {_tmp = call compile format ["%1", _tmp];};
     _queryResult set[5, _tmp];

--- a/life_server/Functions/MySQL/fn_insertRequest.sqf
+++ b/life_server/Functions/MySQL/fn_insertRequest.sqf
@@ -36,7 +36,7 @@ if (EXTDB_SETTING(getNumber,"DebugMode") isEqualTo 1) then {
 
 //Double check to make sure the client isn't in the database...
 if (_queryResult isEqualType "") exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",(owner _returnToSender)];}; //There was an entry!
-if (count _queryResult != 0) exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",(owner _returnToSender)];};
+if !(count _queryResult isEqualTo 0) exitWith {[] remoteExecCall ["SOCK_fnc_dataQuery",(owner _returnToSender)];};
 
 //Clense and prepare some information.
 _name = [_name] call DB_fnc_mresString; //Clense the name of bad chars.

--- a/life_server/Functions/MySQL/fn_mresArray.sqf
+++ b/life_server/Functions/MySQL/fn_mresArray.sqf
@@ -15,7 +15,7 @@ _array = toArray(_array);
 for "_i" from 0 to (count _array)-1 do
 {
     _sel = _array select _i;
-    if ((_i != 0 && _i != ((count _array)-1))) then
+    if ((!(_i isEqualTo 0) && _i != ((count _array)-1))) then
     {
         if (_sel isEqualTo 34) then
         {

--- a/life_server/Functions/MySQL/fn_mresArray.sqf
+++ b/life_server/Functions/MySQL/fn_mresArray.sqf
@@ -15,7 +15,7 @@ _array = toArray(_array);
 for "_i" from 0 to (count _array)-1 do
 {
     _sel = _array select _i;
-    if ((!(_i isEqualTo 0) && _i != ((count _array)-1))) then
+    if (!(_i isEqualTo 0) && !(_i isEqualTo ((count _array)-1))) then
     {
         if (_sel isEqualTo 34) then
         {

--- a/life_server/Functions/MySQL/fn_numberSafe.sqf
+++ b/life_server/Functions/MySQL/fn_numberSafe.sqf
@@ -23,6 +23,6 @@ _modBase = _digitsCount % _mod;
 _numberText = "";
 {
     _numberText = _numberText + str _x;
-    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && _foreachindex != _digitsCount) then {_numberText = _numberText + "";};
+    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && !(_foreachindex isEqualTo _digitsCount)) then {_numberText = _numberText + "";};
 } forEach _digits;
 _numberText

--- a/life_server/Functions/MySQL/fn_queryRequest.sqf
+++ b/life_server/Functions/MySQL/fn_queryRequest.sqf
@@ -140,7 +140,7 @@ switch (_side) do {
         _new = [(_queryResult select 10)] call DB_fnc_mresToArray;
         if (_new isEqualType "") then {_new = call compile format ["%1", _new];};
         _index = TON_fnc_playtime_values_request find [_uid, _new];
-        if (_index != -1) then {
+        if !(_index isEqualTo -1) then {
             TON_fnc_playtime_values_request set[_index,-1];
             TON_fnc_playtime_values_request = TON_fnc_playtime_values_request - [-1];
             TON_fnc_playtime_values_request pushBack [_uid, _new];

--- a/life_server/Functions/Systems/fn_clientDisconnect.sqf
+++ b/life_server/Functions/Systems/fn_clientDisconnect.sqf
@@ -16,7 +16,7 @@ _name = _this select 3;
 _side = side _unit;
 
 //Save player info
-if (isNil "HC_UID" || {_uid != HC_UID}) then {
+if (isNil "HC_UID" || {!(_uid isEqualTo HC_UID)}) then {
     _position = getPosATL _unit;
     if ((getMarkerPos "respawn_civilian" distance _position) > 300) then {
 

--- a/life_server/Functions/Systems/fn_huntingZone.sqf
+++ b/life_server/Functions/Systems/fn_huntingZone.sqf
@@ -22,7 +22,7 @@ _radius = (getMarkerSize _zoneName) select 0;
 _dist = _radius + 100;
 _zone = getMarkerPos _zoneName;
 
-if (!isNil "animals" && {count animals != 0}) then {
+if (!isNil "animals" && {!(count animals isEqualTo 0)}) then {
     _maxAnimals = _maxAnimals - count(animals);
 } else {
     animals = [];

--- a/life_server/Functions/Systems/fn_vehicleStore.sqf
+++ b/life_server/Functions/Systems/fn_vehicleStore.sqf
@@ -64,7 +64,7 @@ if (count _vInfo isEqualTo 0) exitWith {
     (owner _unit) publicVariableClient "life_garage_store";
 };
 
-if (_uid != getPlayerUID _unit) exitWith {
+if !(_uid isEqualTo getPlayerUID _unit) exitWith {
     [1,"STR_Garage_Store_NoOwnership",true] remoteExecCall ["life_fnc_broadcast",(owner _unit)];
     life_garage_store = false;
     (owner _unit) publicVariableClient "life_garage_store";

--- a/life_server/Functions/WantedSystem/fn_wantedAdd.sqf
+++ b/life_server/Functions/WantedSystem/fn_wantedAdd.sqf
@@ -36,10 +36,6 @@ private _val = [_type select 1] call DB_fnc_numberSafe;
 private _number = _type select 0;
 
 if !(count _queryResult isEqualTo 0) then {
-    _crime = format ["SELECT wantedCrimes, wantedBounty FROM wanted WHERE wantedID='%1'",_uid];
-    _crimeresult = [_crime,2] call DB_fnc_asyncCall;
-    _pastcrimess = [_crimeresult select 0] call DB_fnc_mresToArray;
-
     _query = format ["SELECT wantedCrimes, wantedBounty FROM wanted WHERE wantedID='%1'",_uid];
     _queryResult = [_query,2] call DB_fnc_asyncCall;
     _pastCrimes = [_queryResult select 0] call DB_fnc_mresToArray;
@@ -52,6 +48,6 @@ if !(count _queryResult isEqualTo 0) then {
 } else {
     _crime = [_type select 0];
     _crime = [_crime] call DB_fnc_mresArray;
-    _query = format ["INSERT INTO wanted (wantedID, wantedName, wantedCrimes, wantedBounty, active) VALUES('%1', '%2', '%3', '%4', '1')",_uid,_name,_crimes,_val];
+    _query = format ["INSERT INTO wanted (wantedID, wantedName, wantedCrimes, wantedBounty, active) VALUES('%1', '%2', '%3', '%4', '1')",_uid,_name,_crime,_val];
     [_query,1] call DB_fnc_asyncCall;
 };

--- a/life_server/Functions/WantedSystem/fn_wantedProfUpdate.sqf
+++ b/life_server/Functions/WantedSystem/fn_wantedProfUpdate.sqf
@@ -19,7 +19,7 @@ _wantedCheck = format ["SELECT wantedName FROM wanted WHERE wantedID='%1'",_uid]
 _wantedQuery = [_wantedCheck,2] call DB_fnc_asyncCall;
 if (count _wantedQuery isEqualTo 0) exitWith {};
 
-if (_name != (_wantedQuery select 0)) then {
+if !(_name isEqualTo (_wantedQuery select 0)) then {
     _query = format ["UPDATE wanted SET wantedName='%1' WHERE wantedID='%2'",_name,_uid];
     [_query,2] call DB_fnc_asyncCall;
 };


### PR DESCRIPTION
Resolves https://github.com/AsYetUntitled/Framework/issues/166. 

#### Changes proposed in this pull request: 
- Essentially replaces `x != y` with `!(x isEqualTo y)`. 
- Replaced `!(vehicle player isEqualTo player)` with `!(isNull objectParent player)`. 

**Not tested in the slightest.** Any help checking and testing the changes would be greatly appreciated. Do note that due to `isEqualTo` performing case sensitive comparison on [strings](https://community.bistudio.com/wiki/String) it cannot substitute `!=` in all cases. 
