### PR TITLE
Added missing variable declarations

### DIFF
--- a/Altis_Life.Altis/core/medical/fn_revivePlayer.sqf
+++ b/Altis_Life.Altis/core/medical/fn_revivePlayer.sqf
@@ -57,11 +57,11 @@ for "_i" from 0 to 1 step 0 do {
 "progressBar" cutText ["","PLAIN"];
 player playActionNow "stop";
 
-if (_target getVariable ["Reviving",objNull] != player) exitWith {hint localize "STR_Medic_AlreadyReviving"};
+if (_target getVariable ["Reviving",objNull] != player) exitWith {hint localize "STR_Medic_AlreadyReviving"; life_action_inUse = false;};
 _target setVariable ["Reviving",NIL,true];
 
 if (!alive player || life_istazed || life_isknocked) exitWith {life_action_inUse = false;};
-if (_target getVariable ["Revive",false]) exitWith {hint localize "STR_Medic_RevivedRespawned"};
+if (_target getVariable ["Revive",false]) exitWith {hint localize "STR_Medic_RevivedRespawned"; life_action_inUse = false;};
 if (player getVariable ["restrained",false]) exitWith {life_action_inUse = false;};
 if (!isNil "_badDistance") exitWith {titleText[localize "STR_Medic_TooFar","PLAIN"]; life_action_inUse = false;};
 if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; life_action_inUse = false;};


### PR DESCRIPTION
Missing variable declarations on exitWith within fn_revivePlayer.sqf can leave life_action_inUse == true, preventing the client from performing further actions.

#### Changes proposed in this pull request: 
- Added variable = false declarations on exit.
