### PR TITLE
Missing variables on death

### DIFF
--- a/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
@@ -110,11 +110,10 @@ if (!isNull _killer && {!(_killer isEqualTo _unit)} && {!(side _killer isEqualTo
 life_save_gear = [player] call life_fnc_fetchDeadGear;
 
 if (LIFE_SETTINGS(getNumber,"drop_weapons_onDeath") isEqualTo 0) then {
-    _unit removeWeapon (primaryWeapon _unit); 
-    _unit removeWeapon (handgunWeapon _unit); 
-    _unit removeWeapon (secondaryWeapon _unit); 
+    _unit removeWeapon (primaryWeapon _unit);
+    _unit removeWeapon (handgunWeapon _unit);
+    _unit removeWeapon (secondaryWeapon _unit);
 };
-
 
 //Killed by cop stuff...
 if (side _killer isEqualTo west && !(playerSide isEqualTo west)) then {
@@ -132,6 +131,7 @@ if (!isNull _killer && {!(_killer isEqualTo _unit)}) then {
 
 [_unit] call life_fnc_dropItems;
 
+life_action_inUse = false;
 life_hunger = 100;
 life_thirst = 100;
 life_carryWeight = 0;

--- a/Altis_Life.Altis/core/medical/fn_respawned.sqf
+++ b/Altis_Life.Altis/core/medical/fn_respawned.sqf
@@ -9,6 +9,7 @@
 private ["_handle"];
 //Reset our weight and other stuff
 
+life_action_inUse = false;
 life_use_atm = true;
 life_hunger = 100;
 life_thirst = 100;

--- a/Altis_Life.Altis/core/medical/fn_revived.sqf
+++ b/Altis_Life.Altis/core/medical/fn_revived.sqf
@@ -36,6 +36,7 @@ life_corpse setVariable ["name",nil,true];
 [life_corpse] remoteExecCall ["life_fnc_corpse",RANY];
 deleteVehicle life_corpse;
 
+life_action_inUse = false;
 life_is_alive = true;
 
 player setVariable ["Revive",nil,true];


### PR DESCRIPTION
On death, life_action_inUse is not declared false, it is unlikely that this will matter, but is bound to occur at some point, and since this would make users unable to perform certain actions, this would be game breaking until reconnecting in those cases.

#### Changes proposed in this pull request: 
- Declare this variable as false on Player Killed, on Revive and on Respawn.

_Sorry about onPlayerKilled... couldn't get github to recognise that I hadn't changed anything on 113-115._