### PR TITLE
fn_tazed.sqf: Fix typo

### DIFF
--- a/Altis_Life.Altis/core/civilian/fn_tazed.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_tazed.sqf
@@ -54,5 +54,5 @@ if (_shooter isKindOf "Man" && alive player) then {
     };
 } else {
     _unit allowDamage true;
-    life_iztazed = false;
+    life_istazed = false;
 };


### PR DESCRIPTION
Fix typo: Line 57: life_iztazed -> life_istazed

<Please review the guidelines for contributing to this repository. The link is above.>

Resolves little talk on discord

#### Changes proposed in this pull request: 
- fix typo in fn_tazed.sqf, line 57: `life_iztazed` -> `life_istazed`
