### PR TITLE
Removed query char limit

### DIFF
--- a/life_hc/MySQL/General/fn_asyncCall.sqf
+++ b/life_hc/MySQL/General/fn_asyncCall.sqf
@@ -16,19 +16,19 @@ _queryStmt = [_this,0,"",[""]] call BIS_fnc_param;
 _mode = [_this,1,1,[0]] call BIS_fnc_param;
 _multiarr = [_this,2,false,[false]] call BIS_fnc_param;
 
-_key = EXTDB format ["%1:%2:%3",_mode,FETCH_CONST(life_sql_id),_queryStmt];
+_key = EXTDB formatText ["%1:%2:%3",_mode,FETCH_CONST(life_sql_id),_queryStmt];
 
 if (_mode isEqualTo 1) exitWith {true};
 
-_key = call compile format ["%1",_key];
+_key = call compile formatText ["%1",_key];
 _key = (_key select 1);
-_queryResult = EXTDB format ["4:%1", _key];
+_queryResult = EXTDB formatText ["4:%1", _key];
 
 //Make sure the data is received
 if (_queryResult isEqualTo "[3]") then {
     for "_i" from 0 to 1 step 0 do {
         if (!(_queryResult isEqualTo "[3]")) exitWith {};
-        _queryResult = EXTDB format ["4:%1", _key];
+        _queryResult = EXTDB formatText ["4:%1", _key];
     };
 };
 
@@ -37,7 +37,7 @@ if (_queryResult isEqualTo "[5]") then {
     for "_i" from 0 to 1 step 0 do { // extDB3 returned that result is Multi-Part Message
         _queryResult = "";
         for "_i" from 0 to 1 step 0 do {
-            _pipe = EXTDB format ["5:%1", _key];
+            _pipe = EXTDB formatText ["5:%1", _key];
             if (_pipe isEqualTo "") exitWith {_loop = false};
             _queryResult = _queryResult + _pipe;
         };
@@ -45,7 +45,7 @@ if (_queryResult isEqualTo "[5]") then {
     };
 };
 _queryResult = call compile _queryResult;
-if ((_queryResult select 0) isEqualTo 0) exitWith {diag_log format ["extDB3: Protocol Error: %1", _queryResult]; []};
+if ((_queryResult select 0) isEqualTo 0) exitWith {diag_log formatText ["extDB3: Protocol Error: %1", _queryResult]; []};
 _return = (_queryResult select 1);
 if (!_multiarr && count _return > 0) then {
     _return = (_return select 0);

--- a/life_server/Functions/MySQL/fn_asyncCall.sqf
+++ b/life_server/Functions/MySQL/fn_asyncCall.sqf
@@ -16,19 +16,19 @@ _queryStmt = [_this,0,"",[""]] call BIS_fnc_param;
 _mode = [_this,1,1,[0]] call BIS_fnc_param;
 _multiarr = [_this,2,false,[false]] call BIS_fnc_param;
 
-_key = EXTDB format ["%1:%2:%3",_mode,FETCH_CONST(life_sql_id),_queryStmt];
+_key = EXTDB formatText ["%1:%2:%3",_mode,FETCH_CONST(life_sql_id),_queryStmt];
 
 if (_mode isEqualTo 1) exitWith {true};
 
-_key = call compile format ["%1",_key];
+_key = call compile formatText ["%1",_key];
 _key = (_key select 1);
-_queryResult = EXTDB format ["4:%1", _key];
+_queryResult = EXTDB formatText ["4:%1", _key];
 
 //Make sure the data is received
 if (_queryResult isEqualTo "[3]") then {
     for "_i" from 0 to 1 step 0 do {
         if (!(_queryResult isEqualTo "[3]")) exitWith {};
-        _queryResult = EXTDB format ["4:%1", _key];
+        _queryResult = EXTDB formatText ["4:%1", _key];
     };
 };
 
@@ -37,7 +37,7 @@ if (_queryResult isEqualTo "[5]") then {
     for "_i" from 0 to 1 step 0 do { // extDB3 returned that result is Multi-Part Message
         _queryResult = "";
         for "_i" from 0 to 1 step 0 do {
-            _pipe = EXTDB format ["5:%1", _key];
+            _pipe = EXTDB formatText ["5:%1", _key];
             if (_pipe isEqualTo "") exitWith {_loop = false};
             _queryResult = _queryResult + _pipe;
         };
@@ -45,7 +45,7 @@ if (_queryResult isEqualTo "[5]") then {
     };
 };
 _queryResult = call compile _queryResult;
-if ((_queryResult select 0) isEqualTo 0) exitWith {diag_log format ["extDB3: Protocol Error: %1", _queryResult]; []};
+if ((_queryResult select 0) isEqualTo 0) exitWith {diag_log formatText ["extDB3: Protocol Error: %1", _queryResult]; []};
 _return = (_queryResult select 1);
 if (!_multiarr && count _return > 0) then {
     _return = (_return select 0);


### PR DESCRIPTION
The usage of format limits queries and answers to ~8000 chars.
Fixed it with formatText.
New limit is ~1000000 chars.
(You gotta do something for the database part one day)