### PR TITLE
Adding hint parseText format ["",] support

### DIFF
--- a/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
+++ b/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
@@ -44,7 +44,7 @@ if (_type isEqualType []) then {
             case 0: {systemChat _message};
             case 1: {hint format ["%1", _message]};
             case 2: {titleText[format ["%1",_message],"PLAIN"];};
-            case 3: {hint format ["%1", _message]};
+            case 3: {hint parseText format ["%1", _message]};
         };
     };
 } else {
@@ -52,6 +52,6 @@ if (_type isEqualType []) then {
         case 0: {systemChat _message};
         case 1: {hint format ["%1", _message]};
         case 2: {titleText[format ["%1",_message],"PLAIN"];};
-        case 3: {hint format ["%1", _message]};
+        case 3: {hint parseText format ["%1", _message]};
     };
 };

--- a/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
+++ b/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
@@ -52,6 +52,6 @@ if (_type isEqualType []) then {
         case 0: {systemChat _message};
         case 1: {hint format ["%1", _message]};
         case 2: {titleText[format ["%1",_message],"PLAIN"];};
-        case 4: {hint format ["%1", _message]};
+        case 3: {hint format ["%1", _message]};
     };
 };

--- a/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
+++ b/Altis_Life.Altis/core/functions/network/fn_broadcast.sqf
@@ -44,6 +44,7 @@ if (_type isEqualType []) then {
             case 0: {systemChat _message};
             case 1: {hint format ["%1", _message]};
             case 2: {titleText[format ["%1",_message],"PLAIN"];};
+            case 3: {hint format ["%1", _message]};
         };
     };
 } else {
@@ -51,5 +52,6 @@ if (_type isEqualType []) then {
         case 0: {systemChat _message};
         case 1: {hint format ["%1", _message]};
         case 2: {titleText[format ["%1",_message],"PLAIN"];};
+        case 4: {hint format ["%1", _message]};
     };
 };


### PR DESCRIPTION
#### Changes proposed in this pull request: 
-adding support for hint parseText format ["",]

#### Why: 
- Because fn_broadcast did not work with hint parseText format :p 
