### PR TITLE
+ HandleRating EVH

### DIFF
--- a/Altis_Life.Altis/core/fn_initCiv.sqf
+++ b/Altis_Life.Altis/core/fn_initCiv.sqf
@@ -38,4 +38,3 @@ if (life_is_alive && !life_is_arrested) then {
     };
 };
 life_is_alive = true;
-player addRating 9999999;

--- a/Altis_Life.Altis/core/fn_initCop.sqf
+++ b/Altis_Life.Altis/core/fn_initCop.sqf
@@ -6,7 +6,6 @@
     Description:
     Cop Initialization file.
 */
-player addRating 9999999;
 waitUntil {!(isNull (findDisplay 46))};
 
 if (life_blacklisted) exitWith {

--- a/Altis_Life.Altis/core/fn_initMedic.sqf
+++ b/Altis_Life.Altis/core/fn_initMedic.sqf
@@ -6,7 +6,6 @@
     Description:
     Initializes the medic..
 */
-player addRating 99999999;
 waitUntil {!(isNull (findDisplay 46))};
 
 if ((FETCH_CONST(life_medicLevel)) < 1 && (FETCH_CONST(life_adminlevel) isEqualTo 0)) exitWith {

--- a/Altis_Life.Altis/core/fn_setupEVH.sqf
+++ b/Altis_Life.Altis/core/fn_setupEVH.sqf
@@ -5,11 +5,11 @@
     Description:
     Master eventhandler file
 */
-player addEventHandler["Killed", {_this call life_fnc_onPlayerKilled}];
-player addEventHandler["handleDamage",{_this call life_fnc_handleDamage;}];
-player addEventHandler["Respawn", {_this call life_fnc_onPlayerRespawn}];
-player addEventHandler["Take",{_this call life_fnc_onTakeItem}]; //Prevent people from taking stuff they shouldn't...
-player addEventHandler["Fired",{_this call life_fnc_onFired}];
-player addEventHandler["InventoryClosed", {_this call life_fnc_inventoryClosed}];
-player addEventHandler["InventoryOpened", {_this call life_fnc_inventoryOpened}];
-player addEventHandler["HandleRating",{0}];
+player addEventHandler ["Killed", {_this call life_fnc_onPlayerKilled}];
+player addEventHandler ["HandleDamage", {_this call life_fnc_handleDamage}];
+player addEventHandler ["Respawn", {_this call life_fnc_onPlayerRespawn}];
+player addEventHandler ["Take", {_this call life_fnc_onTakeItem}];
+player addEventHandler ["Fired", {_this call life_fnc_onFired}];
+player addEventHandler ["InventoryClosed", {_this call life_fnc_inventoryClosed}];
+player addEventHandler ["InventoryOpened", {_this call life_fnc_inventoryOpened}];
+player addEventHandler ["HandleRating", {0}];

--- a/Altis_Life.Altis/core/fn_setupEVH.sqf
+++ b/Altis_Life.Altis/core/fn_setupEVH.sqf
@@ -12,3 +12,4 @@ player addEventHandler["Take",{_this call life_fnc_onTakeItem}]; //Prevent peopl
 player addEventHandler["Fired",{_this call life_fnc_onFired}];
 player addEventHandler["InventoryClosed", {_this call life_fnc_inventoryClosed}];
 player addEventHandler["InventoryOpened", {_this call life_fnc_inventoryOpened}];
+player addEventHandler["HandleRating",{0}];

--- a/Altis_Life.Altis/core/init.sqf
+++ b/Altis_Life.Altis/core/init.sqf
@@ -103,7 +103,6 @@ waitUntil {!(isNull (findDisplay 46))};
 
 diag_log "Display 46 Found";
 (findDisplay 46) displayAddEventHandler ["KeyDown", "_this call life_fnc_keyHandler"];
-player addRating 99999999;
 
 [player,life_settings_enableSidechannel,playerSide] remoteExecCall ["TON_fnc_manageSC",RSERV];
 0 cutText ["","BLACK IN"];

--- a/Altis_Life.Altis/core/medical/fn_onPlayerRespawn.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerRespawn.sqf
@@ -19,7 +19,6 @@ _unit setVariable ["playerSurrender",false,true];
 _unit setVariable ["steam64id",getPlayerUID player,true]; //Reset the UID.
 _unit setVariable ["realname",profileName,true]; //Reset the players name.
 
-_unit addRating 1e12; //Set our rating to a high value, this is for a ARMA engine thing.
 player playMoveNow "AmovPpneMstpSrasWrflDnon";
 
 [] call life_fnc_setupActions;


### PR DESCRIPTION
Adds in the "HandleRating" EVH to prevent you from going to side enemy by just always keeping your rating at zero. Helps for scripts that use side evaluations and is obviously better then trying to prevent by using _addrating 9999999_ everywhere.