### PR TITLE
Update say3D function to support alternative syntax

### DIFF
--- a/Altis_Life.Altis/core/functions/network/fn_say3D.sqf
+++ b/Altis_Life.Altis/core/functions/network/fn_say3D.sqf
@@ -1,14 +1,31 @@
 /*
     File: fn_say3D.sqf
     Author: Bryan "Tonic" Boardwine
+    Modified: Optimisations and applicability for say3D alt. syntax by SimZor
 
-    Description: Pass your sounds that you want everyone nearby to hear through here.
+    Description: 
+        Pass your sounds that you want everyone nearby to hear through here. 
+        Function usable when sounds needs to be broadcasted globally so everyone can hear them, should be used via remote execution.
 
-    Example:   [_veh,"unlock"] remoteExec ["life_fnc_say3D",RANY];
+    Example(s):
+        1: [vehicle player, "siren"] remoteExecCall ["life_fnc_say3D", RANY];
+        2: [objNull, "", ["soundName", maxDistance, pitch] remoteExecCall ["life_fnc_say3D", RANY];
+        3: [objNull, "", ["soundNae", maxDistance, pitch], [from, to]] remoteExecCall ["life_fnc_say3D", RANY];
 */
-private ["_object","_sound"];
-_object = [_this,0,objNull,[objNull]] call BIS_fnc_param;
-_sound = [_this,1,"",[""]] call BIS_fnc_param;
 
-if (isNull _object || _sound isEqualTo "") exitWith {};
-_object say3D _sound;
+params [
+    ["_object", objNull, [objNull]],
+    ["_soundID", "", [""]],
+    ["_altSyntax", [], [[]]],
+    ["_altSyntax2", [], [[]]]
+];
+
+if (isNull _object) exitWith {};
+if (_soundID isEqualTo "") exitWith {};
+
+// Setup arguments to pass into say3D command
+private _arguments = [_soundID, _altSyntax] select !(_altSyntax isEqualTo []);
+private _objectArguments = [_object, _altSyntax2] select !(_altSyntax2 isEqualTo []);
+
+// Play Sound
+_objectArguments say3D _arguments


### PR DESCRIPTION
Resolves #366 

#### Changes proposed in this pull request: 
- Make ``life_fnc_say3D`` network function applicable together with SQF alternative syntax 1 and 2 for ``say3D`` command as seen at the following link [https://community.bistudio.com/wiki/say3D].
