### PR TITLE
Updated: ArmA RPG Life Discord Invite Link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,5 +75,5 @@ Contributing to AsYetUntitled
 * See [issues](https://github.com/AsYetUntitled/Framework/issues) for a full list of all open tasks and bugs. If you would like to work on a solution to an issue then please leave a comment on that issue so that others know a solution is in progress. 
 
 ## Contact
-* If you need to chat with us in real-time then you can do so on the [ArmA RPG Life Discord server](https://discordapp.com/invite/sEcQdPn). 
+* If you need to chat with us in real-time then you can do so on the [ArmA RPG Life Discord server](https://discord.gg/EaB7Jgw). 
   * Please be sure to read the rules which can be found in the #announcements channel. 

--- a/Altis_Life.Altis/core/fn_welcomeNotification.sqf
+++ b/Altis_Life.Altis/core/fn_welcomeNotification.sqf
@@ -29,7 +29,7 @@ _message = _message + "<t align='center' size='8' shadow='0'><img image='texture
 _message = _message + "Useful links (click on the links to open your browser)<br /><br />";
 _message = _message + " <a href='https://github.com/AsYetUntitled/Framework' color='#56BDD6'>AsYetUntitled</a> -- The official repository for the project.<br /><br />";
 _message = _message + "TeamSpeak 3 address: ADDRESS HERE  <br /><br />";
-_message = _message + "Discord invite: <a href='https://discord.gg/sEcQdPn' color='#56BDD6'>ArmA RPG Life</a>  <br /><br />";
+_message = _message + "Discord invite: <a href='https://discord.gg/EaB7Jgw' color='#56BDD6'>ArmA RPG Life</a>  <br /><br />";
 
 //Fill only the first text
 _text1 ctrlSetStructuredText (parseText _message);

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Github is not currently associated with any forums.
 Altis Life RPG by AsYetUntitled is licensed under a [Creative Commons Attribution-NonCommercial-NoDerivs 4.0 International License] (http://creativecommons.org/licenses/by-nc-nd/4.0/deed.en_US)
 
 # Links:
-  - Discord: https://discord.gg/sEcQdPn
+  - Discord: https://discord.gg/EaB7Jgw
   - Forums: TBD
   - Wiki: https://github.com/AsYetUntitled/Framework/wiki 
   - Releases (Stable Builds): https://github.com/AsYetUntitled/Framework/releases
@@ -27,7 +27,7 @@ Altis Life RPG by AsYetUntitled is licensed under a [Creative Commons Attributio
     <a href="https://travis-ci.org/AsYetUntitled/Framework">
         <img src="https://api.travis-ci.org/AsYetUntitled/Framework.svg" alt="Build Status">
     </a>
-       <a href="https://discord.gg/5Sz7XTc">
-        <img src="https://img.shields.io/badge/Discord-Join%20chat%20→-738bd7.svg" alt="Join the chat at https://discord.gg/yfAMTFp">
+       <a href="https://discord.gg/EaB7Jgw">
+        <img src="https://img.shields.io/badge/Discord-Join%20chat%20→-738bd7.svg" alt="Join the chat at https://discord.gg/EaB7Jgw">
     </a>
 </p>


### PR DESCRIPTION
#### Changes proposed in this pull request: 
- Updated expired and invalid links. New invite directs `#general` channel. Does not expire. 
