### PR TITLE
Add: .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# editorconfig.org
+# Some editors do not have native support for EditorConfig and require a plugin.
+# For a list of those editors and a plugin for them, see http://editorconfig.org/#download
+
+# Top-most EditorConfig file
+root = true
+
+# Every file
+[*]
+# Soft tabs
+indent_style = space
+# 1 indent is 4 spaces
+indent_size = 4
+# Windows-style newlines
+end_of_line = crlf
+# Set default character encoding
+charset = utf-8
+# Remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = true
+# A newline ending every file
+insert_final_newline = true
+
+# Markdown files
+[*.md]
+# Do not remove any whitespace characters preceding newline characters
+trim_trailing_whitespace = false


### PR DESCRIPTION
#### Changes proposed in this pull request: 
- Add `.editorconfig` file in the repository's root directory. 
  - > [EditorConfig](http://editorconfig.org/) helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems. 
  - List of [EditorConfig Properties](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties). 
  - [EditorConfig GitHub organisation](https://github.com/editorconfig/)

Editors such as that in GitHub come bundled with native support for EditorConfig. Others such as [Atom](https://atom.io/) and [Notepad++](https://notepad-plus-plus.org/) require a plugin to be able to use EditorConfig. See [EditorConfig #download](http://editorconfig.org/#download) for a list of editors with native support and a list of editors that require a plugin. 

Your thoughts, @AsYetUntitled/collaborators? 
