### PR TITLE
Fix Undefined Variable life_preview_3D_vehicle_object and Police Escort Bug

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
+++ b/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
@@ -11,7 +11,7 @@ _unit = player getVariable ["escortingPlayer",objNull];
 if (isNull _unit) then {_unit = cursorTarget;}; //Emergency fallback.
 if (isNull _unit) exitWith {}; //Target not found even after using cursorTarget.
 if (!(_unit getVariable ["Escorting",false])) exitWith {}; //He's not being Escorted.
-if !(side _unit isEqualTo civilian) exitWith {}; //Not a civ
+if !(side _unit in [civilian,independent]) exitWith {}; //Not a civ or indep
 detach _unit;
 _unit setVariable ["Escorting",false,true];
 player setVariable ["currentlyEscorting",nil];

--- a/Altis_Life.Altis/core/shops/fn_vehicleShopInit3DPreview.sqf
+++ b/Altis_Life.Altis/core/shops/fn_vehicleShopInit3DPreview.sqf
@@ -33,6 +33,7 @@ life_preview_3D_vehicle_object = objNull;
         private ["_object","_distanceCam","_azimuthCam"];
 
         // Waiting for a view object.
+        waitUntil {!isNil "life_preview_3D_vehicle_object"};
         waitUntil {!isNull life_preview_3D_vehicle_object};
 
         _object = life_preview_3D_vehicle_object;


### PR DESCRIPTION
Resolves #154 and #325 

#### Changes proposed in this pull request: 
- Updated fn_stopEscorting.sqf to match fn_escortAction.sqf allowing independent to be escorted and dropped.
- Check if life_preview_3D_vehicle_object isNil before performing further actions to prevent undefined variable errors as suggested.