### PR TITLE
Remove a Stop Escorting Check

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
+++ b/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
@@ -6,12 +6,11 @@
     Description:
     Detaches player(_unit) from the Escorter(player) and sets them back down.
 */
-private ["_unit"];
-_unit = player getVariable ["escortingPlayer",objNull];
+
+private _unit = player getVariable ["escortingPlayer",objNull];
 if (isNull _unit) then {_unit = cursorTarget;}; //Emergency fallback.
 if (isNull _unit) exitWith {}; //Target not found even after using cursorTarget.
 if (!(_unit getVariable ["Escorting",false])) exitWith {}; //He's not being Escorted.
-if !(side _unit isEqualTo civilian) exitWith {}; //Not a civ
 detach _unit;
 _unit setVariable ["Escorting",false,true];
 player setVariable ["currentlyEscorting",nil];


### PR DESCRIPTION
Very small PR here.

if !(side _unit isEqualTo civilian) exitWith {}; //Not a civ
wasn't required and causing issues when escorting medics, if you were to check against side it makes sense to check before escorting, however checking after they have been escorted does not make much sense.

<Please review the guidelines for contributing to this repository. The link is above.>

Resolves #325. <If applicable.>

#### Changes proposed in this pull request: 
- Remove unnecessary check 
