### PR TITLE
Sync Data upon open of a vehicle's inventory.

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_inventoryOpened.sqf
+++ b/Altis_Life.Altis/core/functions/fn_inventoryOpened.sqf
@@ -28,7 +28,7 @@ if ((typeOf _container) in ["Box_IND_Grenades_F","B_supplyCrate_F"]) exitWith {
 _list = ["LandVehicle","Ship","Air"];
 if (KINDOF_ARRAY(_container,_list)) exitWith {
 
-    [] call SOCK_fnc_syncData;
+    [] call SOCK_fnc_updateRequest;
     
     if (!(_container in life_vehicles) && {locked _container isEqualTo 2}) exitWith {
         hint localize "STR_MISC_VehInventory";

--- a/Altis_Life.Altis/core/functions/fn_inventoryOpened.sqf
+++ b/Altis_Life.Altis/core/functions/fn_inventoryOpened.sqf
@@ -27,6 +27,9 @@ if ((typeOf _container) in ["Box_IND_Grenades_F","B_supplyCrate_F"]) exitWith {
 
 _list = ["LandVehicle","Ship","Air"];
 if (KINDOF_ARRAY(_container,_list)) exitWith {
+
+    [] call SOCK_fnc_syncData;
+    
     if (!(_container in life_vehicles) && {locked _container isEqualTo 2}) exitWith {
         hint localize "STR_MISC_VehInventory";
         true;


### PR DESCRIPTION
Should solve this issue, please can someone test before full commit.

Resolves #361 

#### Changes proposed in this pull request: 
- Sync Data upon Opening a vehicle inventory, avoid duplication of physical ArmA Items.
