### PR TITLE
Fix possible bug with fn_calWeightDiff

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_calWeightDiff.sqf
+++ b/Altis_Life.Altis/core/functions/fn_calWeightDiff.sqf
@@ -17,5 +17,6 @@ if !(
 ) exitWith {-1};
 
 private _iWeight = [_item] call life_fnc_itemWeight;
+if (_iWeight isEqualTo 0) exitWith {_value};
 
 (floor ((_mWeight - _cWeight) / _iWeight)) min _value;


### PR DESCRIPTION
<!--
Please review the guidelines for contributing to this repository. The link is above.
-->

Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- If an item weights 0 (not in default configs), zero divisor error occurs, this fixes that.
