### PR TITLE
Optimize Mysql fnc_mresArray

### DIFF
--- a/life_server/Functions/MySQL/fn_mresArray.sqf
+++ b/life_server/Functions/MySQL/fn_mresArray.sqf
@@ -7,21 +7,7 @@
     can be properly inserted into the database without causing
     any problems. The return method is 'hacky' but it's effective.
 */
-private ["_array"];
-_array = [_this,0,[],[[]]] call BIS_fnc_param;
-_array = str _array;
-_array = toArray(_array);
 
-for "_i" from 0 to (count _array)-1 do
-{
-    _sel = _array select _i;
-    if (!(_i isEqualTo 0) && !(_i isEqualTo ((count _array)-1))) then
-    {
-        if (_sel isEqualTo 34) then
-        {
-            _array set[_i,96];
-        };
-    };
-};
+params ["_array"];
 
-str(toString(_array));
+str toString ((toArray str _array) apply {[_x, 96] select (_x isEqualTo 34)})

--- a/life_server/Functions/MySQL/fn_mresArray.sqf
+++ b/life_server/Functions/MySQL/fn_mresArray.sqf
@@ -10,6 +10,4 @@
 
 params ["_array"];
 
-private _input = str _array;
-
-str ((_input splitString '"') joinString "`")
+str toString ((toArray str _array) apply {[_x, 96] select (_x isEqualTo 34)})

--- a/life_server/Functions/MySQL/fn_mresArray.sqf
+++ b/life_server/Functions/MySQL/fn_mresArray.sqf
@@ -10,4 +10,6 @@
 
 params ["_array"];
 
-str toString ((toArray str _array) apply {[_x, 96] select (_x isEqualTo 34)})
+private _input = str _array;
+
+str ((_input splitString '"') joinString "`")


### PR DESCRIPTION
old: 3.3966ms
new: 1.1325ms
~new: 0.048ms~ This one was broken. Output was ```[`,`,`,`]``` instead of ```[``,``,``,``]```
Testarray: 
```
["76561xxxxxxxxxxxx",CIV,["TRYK_U_B_BLKBLK_R_CombatUniform","V_PlateCarrier1_blk","TRYK_B_Belt_AOR1","G_Balaclava_blk","CUP_H_TKI_Lungee_02",["ItemMap","ItemCompass","Itemwatch","tf_pnr1000a_1","ItemGPS","Binocular"],"hlc_rifle_rpk","",[],["hlc_30Rnd_762x39_b_ak"],["NVGoggles_INDEP","FirstAidKit","FirstAidKit"],[],[],[],["","","",""],["","","",""],[]],3]
```
Test output:
```
"""[`76561xxxxxxxxxxxx`,any,[`TRYK_U_B_BLKBLK_R_CombatUniform`,`V_PlateCarrier1_blk`,`TRYK_B_Belt_AOR1`,`G_Balaclava_blk`,`CUP_H_TKI_Lungee_02`,[`ItemMap`,`ItemCompass`,`Itemwatch`,`tf_pnr1000a_1`,`ItemGPS`,`Binocular`],`hlc_rifle_rpk`,``,[],[`hlc_30Rnd_762x39_b_ak`],[`NVGoggles_INDEP`,`FirstAidKit`,`FirstAidKit`],[],[],[],[``,``,``,``],[``,``,``,``],[]],3]"""
```
<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- <!-- Describe the changes that your pull request makes. -->

- [ ] I have tested my changes and corrected any errors found
