### PR TITLE
optimize Mysql fnc_numberSafe

### DIFF
--- a/life_server/Functions/MySQL/fn_numberSafe.sqf
+++ b/life_server/Functions/MySQL/fn_numberSafe.sqf
@@ -11,18 +11,6 @@
     Returns:
     STRING
 */
-private ["_number","_mod","_digots","_digitsCount","_modBase","_numberText"];
+params ["_number"];
 
-_number = [_this,0,0,[0]] call bis_fnc_param;
-_mod = [_this,1,3,[0]] call bis_fnc_param;
-
-_digits = _number call bis_fnc_numberDigits;
-_digitsCount = count _digits - 1;
-
-_modBase = _digitsCount % _mod;
-_numberText = "";
-{
-    _numberText = _numberText + str _x;
-    if ((_foreachindex - _modBase) % (_mod) isEqualTo 0 && !(_foreachindex isEqualTo _digitsCount)) then {_numberText = _numberText + "";};
-} forEach _digits;
-_numberText
+_number toFixed 0;


### PR DESCRIPTION
input `[1234241.1231231231]`

Old: 0.361ms output: `"1234241"`
New: 0.0057ms output: `"1234241"`

I don't know what _mod parameter is supposed to do though. No values that I tried for it changed anything.

<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- <!-- Describe the changes that your pull request makes. -->

- [ ] I have tested my changes and corrected any errors found
