### PR TITLE
Blasting charge improvements

### DIFF
--- a/Altis_Life.Altis/core/items/fn_blastingCharge.sqf
+++ b/Altis_Life.Altis/core/items/fn_blastingCharge.sqf
@@ -10,6 +10,7 @@
 private ["_vault","_handle"];
 _vault = param [0,ObjNull,[ObjNull]];
 
+if (playerSide != civilian) exitWith {};
 if (isNull _vault) exitWith {}; //Bad object
 if (typeOf _vault != "Land_CargoBox_V1_F") exitWith {hint localize "STR_ISTR_Blast_VaultOnly"};
 if (_vault getVariable ["chargeplaced",false]) exitWith {hint localize "STR_ISTR_Blast_AlreadyPlaced"};

--- a/Altis_Life.Altis/core/items/fn_blastingCharge.sqf
+++ b/Altis_Life.Altis/core/items/fn_blastingCharge.sqf
@@ -2,6 +2,7 @@
 /*
     File: fn_blastingCharge.sqf
     Author: Bryan "Tonic" Boardwine
+    Editted by: Robin Withes
 
     Description:
     Blasting charge is used for the federal reserve vault and nothing  more.. Yet.
@@ -29,5 +30,10 @@ _vault setVariable ["chargeplaced",true,true];
 [0,"STR_ISTR_Blast_Placed",true,[]] remoteExecCall ["life_fnc_broadcast",west];
 hint localize "STR_ISTR_Blast_KeepOff";
 
-[] remoteExec ["life_fnc_demoChargeTimer",[west,player]];
+[] remoteExec ["life_fnc_demoChargeTimer",west];
+if (isNil {(group player) getVariable "gang_name"}) then {
+    [] remoteExec ["life_fnc_demoChargeTimer",player];
+} else {
+    [] remoteExec ["life_fnc_demoChargeTimer",group player];
+};
 [] remoteExec ["TON_fnc_handleBlastingCharge",2];


### PR DESCRIPTION
Changes proposed in this pull request: 
If local player is in a valid altis life gang group then the bank timer will also show up on every online group member of that player. I also added a sidecheck in the script since i did not see any in both the blastingcharge and useitem script.

- I have tested my changes and corrected any errors found
