### PR TITLE
Police crash tackle added

### DIFF
--- a/Altis_Life.Altis/core/civilian/fn_knockoutAction.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_knockoutAction.sqf
@@ -13,6 +13,9 @@ _target = param [0,objNull,[objNull]];
 if (isNull _target) exitWith {};
 if (!isPlayer _target) exitWith {};
 if (player distance _target > 4) exitWith {};
+
+
+if (playerSide isEqualTo civilian) then {
 life_knockout = true;
 [player,"AwopPercMstpSgthWrflDnon_End2"] remoteExecCall ["life_fnc_animSync",RCLIENT];
 sleep 0.08;
@@ -20,3 +23,27 @@ sleep 0.08;
 
 sleep 3;
 life_knockout = false;
+
+} else {
+
+_degrees = getDir player; 
+_degreesu = getDir _target;
+_totald = _degrees - _degreesu;
+
+if !(_totald >= -90 && _totald < 1 || _totald <= 90 && _totald > -1 || _totald >= 270 || _totald <= -270) exitWith {
+hint "You need to be behind your target to knock them out!";
+};
+
+player attachTo [_target, [0, -0.4, 0.1] ];
+detach player; 
+_obj = "Land_ClutterCutter_small_F" createVehicle (getPosATL player); 
+player switchmove "AmovPpneMstpSnonWnonDnon";
+_obj setPosATL (getPosATL player);  
+player attachTo [_obj,[0,-0.3,0.7]]; 
+detach player;
+[_target,profileName] remoteExec ["life_fnc_knockedOut",_target];
+uiSleep 3;
+life_knockout = false;
+deleteVehicle _obj;
+
+}

--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -160,7 +160,7 @@ switch (_code) do {
     //Knock out, this is experimental and yeah... (Shift + G)
     case 34: {
         if (_shift) then {_handled = true;};
-        if (_shift && playerSide isEqualTo civilian && !isNull cursorObject && cursorObject isKindOf "Man" && isPlayer cursorObject && alive cursorObject && cursorObject distance player < 4 && speed cursorObject < 1) then {
+        if (_shift && playerSide != independent && !isNull cursorObject && cursorObject isKindOf "Man" && isPlayer cursorObject && alive cursorObject && cursorObject distance player < 4 && ((speed cursorObject < 1 && playerSide isEqualTo civilian) || (speed cursorObject < 7 && playerSide isEqualTo west))) then {
             if ((animationState cursorObject) != "Incapacitated" && (currentWeapon player == primaryWeapon player || currentWeapon player == handgunWeapon player) && currentWeapon player != "" && !life_knockout && !(player getVariable ["restrained",false]) && !life_istazed && !life_isknocked) then {
                 [cursorObject] spawn life_fnc_knockoutAction;
             };


### PR DESCRIPTION
Police can now shift g people if they are behind someone and have a weapon out. This will do a unique animation that resembles tackling the player targeted.

- [ ] I have tested my changes and corrected any errors found
