### PR TITLE
Fix resolution scaling on the clothing shop.

### DIFF
--- a/Altis_Life.Altis/dialog/clothing.hpp
+++ b/Altis_Life.Altis/dialog/clothing.hpp
@@ -9,8 +9,8 @@ class Life_Clothing {
         class Life_RscTitleBackground: Life_RscText {
             colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.3843])", "(profilenamespace getvariable ['GUI_BCG_RGB_G',0.7019])", "(profilenamespace getvariable ['GUI_BCG_RGB_B',0.8862])", "(profilenamespace getvariable ['GUI_BCG_RGB_A',0.7])"};
             idc = -1;
-            x = 0.0821059 * safezoneW + safezoneX;
-            y = 0.212176 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0;
             w = 0.318;
             h = (1 / 25);
         };
@@ -18,8 +18,8 @@ class Life_Clothing {
         class MainBackground: Life_RscText {
             colorBackground[] = {0, 0, 0, 0.7};
             idc = -1;
-            x = 0.0822359 * safezoneW + safezoneX;
-            y = 0.236099 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0 + (11 / 250);
             w = 0.318;
             h = 0.5 - (22 / 250);
         };
@@ -30,8 +30,8 @@ class Life_Clothing {
             colorBackground[] = {0, 0, 0, 0};
             idc = 3103;
             text = "";
-            x = 0.0821059 * safezoneW + safezoneX;
-            y = 0.212176 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0;
             w = 0.6;
             h = (1 / 25);
         };
@@ -41,8 +41,8 @@ class Life_Clothing {
             text = "";
             sizeEx = 0.035;
             onLBSelChanged = "[_this] call life_fnc_changeClothes;";
-            x = 0.0842977 * safezoneW + safezoneX;
-            y = 0.240498 * safezoneH + safezoneY;
+            x = -0.29;
+            y = 0.05;
             w = 0.3;
             h = 0.35;
         };
@@ -51,8 +51,8 @@ class Life_Clothing {
             idc = 3102;
             text = "";
             sizeEx = 0.035;
-            x = 0.0853304 * safezoneW + safezoneX;
-            y = 0.439419 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0.45 - (1 / 25);
             w = 0.2;
             h = (1 / 25);
         };
@@ -61,8 +61,8 @@ class Life_Clothing {
             idc = 3106;
             text = "";
             sizeEx = 0.035;
-            x = 0.148258 * safezoneW + safezoneX;
-            y = 0.439419 * safezoneH + safezoneY;
+            x = -0.15;
+            y = 00.45 - (1 / 25);
             w = 0.2;
             h = (1 / 25);
         };
@@ -71,8 +71,8 @@ class Life_Clothing {
             idc = 3105;
             colorBackground[] = {0,0,0,0.7};
             onLBSelChanged  = "_this call life_fnc_clothingFilter";
-            x = 0.0822359 * safezoneW + safezoneX;
-            y = 0.468 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0.5 - (1 / 25);
             w = 0.318;
             h = 0.035;
         };
@@ -81,8 +81,8 @@ class Life_Clothing {
             idc = -1;
             text = "$STR_Global_Close";
             onButtonClick = "closeDialog 0; [] call life_fnc_playerSkins;";
-            x = 0.157 * safezoneW + safezoneX;
-            y = 0.489992 * safezoneH + safezoneY;
+            x = -0.14;
+            y = 0.54 - (1 / 25);
             w = (6.25 / 40);
             h = (1 / 25);
         };
@@ -91,8 +91,8 @@ class Life_Clothing {
             idc = -1;
             text = "$STR_Global_Buy";
             onButtonClick = "[] call life_fnc_buyClothes;";
-            x = 0.0822359 * safezoneW + safezoneX;
-            y = 0.489992 * safezoneH + safezoneY;
+            x = -0.30;
+            y = 0.54 - (1 / 25);
             w = (6.25 / 40);
             h = (1 / 25);
         };


### PR DESCRIPTION
On resolutions that are sub 1920x1080 the clothing menu buttons, etc. will move into each other making it hard to press the buttons.

This should fix it!
I just made a pull request for it. As there wasn't one.

<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves #303 

#### Changes proposed in this pull request: 
To remove safezones in clothing.hpp

- [x] I have tested my changes and corrected any errors found
