### PR TITLE
Optimization fn_clearVehicleAmmo.sqf

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
@@ -9,31 +9,14 @@
     Syntax: _vehicle removeMagazinesTurret [magazineName, turretPath]
     Documentation: https://community.bistudio.com/wiki/removeMagazinesTurret
 */
-private ["_vehicle","_veh"];
-_vehicle = [_this,0,objNull,[objNull]] call BIS_fnc_param;
+params [["_vehicle",objNull,[objNull]]];
 if (isNull _vehicle) exitWith {};
-_veh = typeOf _vehicle;
+private _veh = typeOf _vehicle;
 
-if (_veh isEqualTo "B_Boat_Armed_01_minigun_F") then {
-    _vehicle removeMagazinesTurret ["200Rnd_40mm_G_belt",[0]];
-};
-
-if (_veh isEqualTo "B_APC_Wheeled_01_cannon_F") then {
-    _vehicle removeMagazinesTurret ["60Rnd_40mm_GPR_Tracer_Red_shells",[0]];
-    _vehicle removeMagazinesTurret ["40Rnd_40mm_APFSDS_Tracer_Red_shells",[0]];
-};
-
-if (_veh isEqualTo "O_Heli_Attack_02_black_F") then {
-    _vehicle removeMagazinesTurret ["250Rnd_30mm_APDS_shells",[0]];
-    _vehicle removeMagazinesTurret ["8Rnd_LG_scalpel",[0]];
-    _vehicle removeMagazinesTurret ["38Rnd_80mm_rockets",[0]];
-};
-
-if (_veh isEqualTo "B_Heli_Transport_01_F") then {
-    _vehicle removeMagazinesTurret ["2000Rnd_65x39_Belt_Tracer_Red",[1]];
-    _vehicle removeMagazinesTurret ["2000Rnd_65x39_Belt_Tracer_Red",[2]];
-};
-
+{
+	if !(_x in ["SportCarHorn","MiniCarHorn","CarHorn","CarHorn","PoliceHorn","PoliceHorn","TruckHorn3","AmbulanceHorn","TruckHorn2"]) then {_vehicle removeWeapon _x};
+} forEach weapons _vehicle;
+{_vehicle removeMagazine _x} forEach magazines _vehicle;
 clearWeaponCargoGlobal _vehicle;
 clearMagazineCargoGlobal _vehicle;
 clearItemCargoGlobal _vehicle;

--- a/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
@@ -14,7 +14,7 @@ if (isNull _vehicle) exitWith {};
 private _veh = typeOf _vehicle;
 
 {
-	if !(_x in ["SportCarHorn","MiniCarHorn","CarHorn","CarHorn","PoliceHorn","PoliceHorn","TruckHorn3","AmbulanceHorn","TruckHorn2"]) then {_vehicle removeWeapon _x};
+    if !(_x in ["SportCarHorn","MiniCarHorn","CarHorn","CarHorn","PoliceHorn","PoliceHorn","TruckHorn3","AmbulanceHorn","TruckHorn2"]) then {_vehicle removeWeapon _x};
 } forEach weapons _vehicle;
 {_vehicle removeMagazine _x} forEach magazines _vehicle;
 clearWeaponCargoGlobal _vehicle;


### PR DESCRIPTION
No you haven't to take care about the weapons of a vehicle. All weapons are deactivate for all vehicles. If you want you can add exceptions. Please make sure that you activate all horns because they are WEAPONS :-X

Feature: easier to handle new configured vehicles

#### Changes proposed in this pull request: 
Removed all configurations for single vehicles and added a global rule

- [ x] I have tested my changes and corrected any errors found
