### PR TITLE
Rework fn_fetchVehInfo.sqf

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
@@ -1,7 +1,7 @@
-#include "..\..\script_macros.hpp"
 /*
     File: fn_fetchVehInfo.sqf
     Author: Bryan "Tonic" Boardwine
+    Edited: blackfisch
 
     Description:
     Used in returning information about a vehicle from Config >> "CfgVehicles"
@@ -21,37 +21,28 @@
     11: Max Horse power
     12: Fuel Capacity
 */
-private ["_class","_scope","_picture","_displayName","_vehicleClass","_side","_faction","_superClass","_speed","_armor","_seats","_hp","_fuel"];
-_class = [_this,0,"",[""]] call BIS_fnc_param;
+if !(params [
+    ["_class","",[""]]
+]) exitWith {[]}; //Bad params
 if (_class isEqualTo "") exitWith {[]}; //Bad class passed.
 if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {[]}; //Class doesn't exist in CfgVehicles
 
-//Predefine some stuff.
-_scope = -1;
-_picture = "";
-_displayName = "";
-_vehicleClass = "";
-_side = -1;
-_faction = "";
-_speed = 0;
-_armor = 0;
-_seats = 0;
-_hp = 0;
-_fuel = 0;
+//prepare config
+private _config = (configFile >> "CfgVehicles" >> _class);
 
 //Fetch
-_scope = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"scope");
-_picture = FETCH_CONFIG2(getText,"CfgVehicles",_class,"picture");
-_displayName = FETCH_CONFIG2(getText,"CfgVehicles",_class,"displayName");
-_vehicleClass = FETCH_CONFIG2(getText,"CfgVehicles",_class,"vehicleClass");
-_side = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"side");
-_faction = FETCH_CONFIG2(getText,"CfgVehicles",_class,"faction");
-_superClass = BASE_CONFIG("CfgVehicles",_class);
-_speed = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"maxSpeed");
-_armor = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"armor");
-_seats = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"transportSoldier");
-_hp = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"enginePower");
-_fuel = FETCH_CONFIG2(getNumber,"CfgVehicles",_class,"fuelCapacity");
+private _scope = getNumber(_config >> "scope");
+private _picture = getText(_config >> "picture");
+private _displayName = getText(_config >> "picture");
+private _vehicleClass = getText(_config >> "vehicleClass");
+private _side = getNumber(_config >> "side");
+private _faction = getText(_config >> "faction");
+private _superClass = inheritsFrom _config;
+private _speed = getNumber(_config >> "maxSpeed");
+private _armor = getNumber(_config >> "armor");
+private _seats = getNumber(_config >> "transportSoldier") + count ("true" configClasses (_config >> "Turrets")); //number of seats = number of passengers + number of vehicle turrets
+private _hp = getNumber(_config >> "enginePower");
+private _fuel = getNumber(_config >> "fuelCapacity");
 
 //Return
 [_class,_scope,_picture,_displayName,_vehicleClass,_side,_faction,_superClass,_speed,_armor,_seats,_hp,_fuel];

--- a/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
@@ -1,7 +1,6 @@
 /*
     File: fn_fetchVehInfo.sqf
     Author: Bryan "Tonic" Boardwine
-    Edited: blackfisch
 
     Description:
     Used in returning information about a vehicle from Config >> "CfgVehicles"
@@ -25,10 +24,8 @@ params [
     ["_class","",[""]]
 ];
 if (_class isEqualTo "") exitWith {[]}; //Bad class passed.
-if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {[]}; //Class doesn't exist in CfgVehicles
-
-//prepare config
-private _config = (configFile >> "CfgVehicles" >> _class);
+private _config = configFile >> "CfgVehicles" >> _class;
+if (!isClass _config) exitWith {[]}; //Class doesn't exist in CfgVehicles
 
 //Fetch
 private _scope = getNumber(_config >> "scope");

--- a/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_fetchVehInfo.sqf
@@ -21,9 +21,9 @@
     11: Max Horse power
     12: Fuel Capacity
 */
-if !(params [
+params [
     ["_class","",[""]]
-]) exitWith {[]}; //Bad params
+];
 if (_class isEqualTo "") exitWith {[]}; //Bad class passed.
 if (!isClass (configFile >> "CfgVehicles" >> _class)) exitWith {[]}; //Class doesn't exist in CfgVehicles
 


### PR DESCRIPTION
Resolves #541

#### Changes proposed in this pull request: 
- update function to return correct passenger number (see #541)
- removed unncessary "predefinitions" (engine default values should do the job...)
- moved away from overusing `FETCH_Config2`-macro, instead preload the config and fetch values (slight performance increase, could affect delays and such -> https://imgur.com/a/M0p9jRP)
- rewrite function to use `params` instead

- [x] I have tested my changes and corrected any errors found