### PR TITLE
Stringtable Fix: Remove Chinese in Original ATM addAction (NOTF)

### DIFF
--- a/Altis_Life.Altis/stringtable.xml
+++ b/Altis_Life.Altis/stringtable.xml
@@ -4975,7 +4975,7 @@
 			<Chinesesimp>传送 %1 到你的位置。</Chinesesimp>
         </Key>
         <Key ID="STR_NOTF_ATM">
-            <Original>&lt;t color='#ADFF2F'&gt;ATM自动取款机&lt;/t&gt;</Original>
+            <Original>&lt;t color='#ADFF2F'&gt;ATM&lt;/t&gt;</Original>
             <Czech>&lt;t color='#ADFF2F'&gt;Bankomat&lt;/t&gt;</Czech>
             <French>&lt;t color='#ADFF2F'&gt;DAB&lt;/t&gt;</French>
             <Spanish>&lt;t color='#ADFF2F'&gt;ATM&lt;/t&gt;</Spanish>
@@ -4984,6 +4984,7 @@
             <Portuguese>&lt;t color='#ADFF2F'&gt;Caixa Eletrônico&lt;/t&gt;</Portuguese>
             <Russian>&lt;t color='#ADFF2F'&gt;Банкомат&lt;/t&gt;</Russian>
             <German>&lt;t color='#ADFF2F'&gt;Geldautomat&lt;/t&gt;</German>
+            <Chinesesimp>&lt;t color='#ADFF2F'&gt;自动取款机&lt;/t&gt;</Chinesesimp>
         </Key>
         <Key ID="STR_NOTF_captureGangHideout">
             <Original>Capture Gang Hideout</Original>
@@ -10609,7 +10610,7 @@
             <German>Geldautomat</German>
             <Portuguese>Caixa Eletrônico</Portuguese>
             <Polish>Bankomat</Polish>
-			<Chinesesimp>ATM自动取款机</Chinesesimp>
+			<Chinesesimp>自动取款机</Chinesesimp>
         </Key>
         <Key ID="STR_MAR_Local_Bank">
             <Original>Local Bank</Original>


### PR DESCRIPTION
<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves No Issues

#### Changes proposed in this pull request: 
- Removed Chinese characters from Original for STR_NOTF_ATM.
- Added Chinesesimp for STR_NOTF_ATM.
- Remove English "ATM" from Chinesesimp for STR_MAR_ATM.

---

- [x] I have tested my changes and corrected any errors found

