### PR TITLE
Make `gangs` `active` column default consistent.

### DIFF
--- a/altislife.sql
+++ b/altislife.sql
@@ -174,7 +174,7 @@ CREATE TABLE IF NOT EXISTS `gangs` (
     `members`     TEXT,
     `maxmembers`  INT DEFAULT 8,
     `bank`        INT DEFAULT 0,
-    `active`      TINYINT NOT NULL DEFAULT '1',
+    `active`      TINYINT NOT NULL DEFAULT 1,
     `insert_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     
     PRIMARY KEY (`id`),


### PR DESCRIPTION
Resolves None. References Commit 2cf5be13879e69f7e2286a808956551e19b129d0

#### Changes proposed in this pull request: 
- Removes the single quotes from the default integer for the `active` column of the `gangs` table to be consistent with the rest of the file.

---

- [x] I have tested my changes and corrected any errors found
