### PR TITLE
Fix Negative Input Exploit

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_virt_sell.sqf
+++ b/Altis_Life.Altis/core/shops/fn_virt_sell.sqf
@@ -15,6 +15,9 @@ if (_price isEqualTo -1) exitWith {};
 _amount = ctrlText 2405;
 if (!([_amount] call TON_fnc_isnumber)) exitWith {hint localize "STR_Shop_Virt_NoNum";};
 _amount = parseNumber (_amount);
+
+if (_amount < 1) exitWith {hint "you cannot sell less than 1 item"};
+
 if (_amount > (ITEM_VALUE(_type))) exitWith {hint localize "STR_Shop_Virt_NotEnough"};
 if ((time - life_action_delay) < 0.2) exitWith {hint localize "STR_NOTF_ActionDelay";};
 life_action_delay = time;


### PR DESCRIPTION

#### Changes proposed in this pull request: 
- Fixes an exploit where players can enter negative numbers in sell menu eg -999999 and receive the positive number of that item eg 999999 apples

- [x] I have tested my changes and corrected any errors found
