### PR TITLE
Add unsafeCVL parameter to description

### DIFF
--- a/Altis_Life.Altis/description.ext
+++ b/Altis_Life.Altis/description.ext
@@ -1,5 +1,6 @@
 disableChannels[] = {{0,true,true},{1,true,true},{2,true,true}};    // Disabled text and voice for global, side, and command channels. Syntax: disableChannels[] = {{channelID<number>, disableChat<bool>, disableVoice<bool>}};
 overviewText = "$STR_MISC_overviewText";    // Text to be displayed below the overviewPicture on the mission selection screen when the mission is available to play.
+unsafeCVL = 1; // Allows createVehicleLocal to be executed in Multiplayer
 
 #include "config\Config_SpyGlass.hpp"
 #include "CfgRemoteExec.hpp"


### PR DESCRIPTION
#### Changes proposed in this pull request: 
- adding ```unsafeCVL = 1``` to description.ext to allow createVehicleLocal to be executed on multiplayer servers

This is necessary because of the Arma 1.95 Update released a few hours ago.
For reference see:
- https://community.bistudio.com/wiki/Description.ext#unsafeCVL
- https://community.bistudio.com/wiki/createVehicleLocal

- [x] I have tested my changes and corrected any errors found
