### PR TITLE
Swap Cop/Medic Lights Positions to an Array

### DIFF
--- a/Altis_Life.Altis/core/cop/fn_copLights.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copLights.sqf
@@ -23,7 +23,7 @@ _lightLeft setLightBrightness 0.2;
 _lightLeft setLightAmbient [0.1,0.1,1];
 
 //Format: [[left position], [right position]]
-private _offset = switch (typeOf _vehicle) do {
+(switch (typeOf _vehicle) do {
     case "C_Offroad_01_F": {
         [[-0.37, 0.0, 0.56], [0.37, 0.0, 0.56]];
     };
@@ -43,16 +43,16 @@ private _offset = switch (typeOf _vehicle) do {
         [[-0.5, 0.0, 0.81], [0.5, 0.0, 0.81]];
     };
     default {
-        [-1];
+        [[-1], [-1]];
     };
-};
+}) params ["_leftOffset", "_rightOffset"];
 
-if (_offset isEqualTo [-1]) exitWith {
-    diag_log format ["Vehicle emergency lights not set for: %1",_vehicle];
+if (_leftOffset isEqualTo [-1]) exitWith {
+    diag_log format ["Vehicle emergency lights not set for: %1", _vehicle];
     hint localize "STR_NOTF_ELSNotSet";
 };
 
-_lightLeft lightAttachObject [_vehicle, _offset select 0];
+_lightLeft lightAttachObject [_vehicle, _leftOffset];
 
 _lightLeft setLightAttenuation [0.181, 0, 1000, 130];
 _lightLeft setLightIntensity 10;
@@ -66,7 +66,7 @@ _lightRight setLightColor _lightBlue;
 _lightRight setLightBrightness 0.2;
 _lightRight setLightAmbient [0.1,0.1,1];
 
-_lightRight lightAttachObject [_vehicle, _offset select 1];
+_lightRight lightAttachObject [_vehicle, _rightOffset];
 
 _lightRight setLightAttenuation [0.181, 0, 1000, 130];
 _lightRight setLightIntensity 10;

--- a/Altis_Life.Altis/core/cop/fn_copLights.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copLights.sqf
@@ -22,24 +22,25 @@ _lightLeft setLightColor _lightRed;
 _lightLeft setLightBrightness 0.2;
 _lightLeft setLightAmbient [0.1,0.1,1];
 
+//Format: [[left position], [right position]]
 private _offset = switch (typeOf _vehicle) do {
     case "C_Offroad_01_F": {
-        [-0.37, 0.0, 0.56];
+        [[-0.37, 0.0, 0.56], [0.37, 0.0, 0.56]];
     };
     case "B_MRAP_01_F": {
-        [-0.37, -1.9, 0.7];
+        [[-0.37, -1.9, 0.7], [0.37, -1.9, 0.7]];
     };
     case "C_SUV_01_F": {
-        [-0.37,-1.2,0.42];
+        [[-0.37,-1.2,0.42], [0.37,-1.2,0.42]];
     };
     case "C_Hatchback_01_sport_F": {
-        [-0.35,-0.2,0.25];
+        [[-0.35,-0.2,0.25], [0.35,-0.2,0.25]];
     };
     case "B_Heli_Light_01_F": {
-        [-0.37, 0.0, -0.80];
+        [[-0.37, 0.0, -0.80], [0.37, 0.0, -0.80]];
     };
     case "B_Heli_Transport_01_F": {
-        [-0.5, 0.0, 0.81];
+        [[-0.5, 0.0, 0.81], [0.5, 0.0, 0.81]];
     };
     default {
         [-1];
@@ -51,7 +52,7 @@ if (_offset isEqualTo [-1]) exitWith {
     hint localize "STR_NOTF_ELSNotSet";
 };
 
-_lightLeft lightAttachObject [_vehicle, _offset];
+_lightLeft lightAttachObject [_vehicle, _offset select 0];
 
 _lightLeft setLightAttenuation [0.181, 0, 1000, 130];
 _lightLeft setLightIntensity 10;
@@ -65,28 +66,7 @@ _lightRight setLightColor _lightBlue;
 _lightRight setLightBrightness 0.2;
 _lightRight setLightAmbient [0.1,0.1,1];
 
-_offset = switch (typeOf _vehicle) do {
-    case "C_Offroad_01_F": {
-        [0.37, 0.0, 0.56];
-    };
-    case "B_MRAP_01_F": {
-        [0.37, -1.9, 0.7];
-    };
-    case "C_SUV_01_F": {
-        [0.37,-1.2,0.42];
-    };
-    case "C_Hatchback_01_sport_F": {
-        [0.35,-0.2,0.25];
-    };
-    case "B_Heli_Light_01_F": {
-        [0.37, 0.0, -0.80];
-    };
-    case "B_Heli_Transport_01_F": {
-        [0.5, 0.0, 0.81];
-    };
-};
-
-_lightRight lightAttachObject [_vehicle, _offset];
+_lightRight lightAttachObject [_vehicle, _offset select 1];
 
 _lightRight setLightAttenuation [0.181, 0, 1000, 130];
 _lightRight setLightIntensity 10;

--- a/Altis_Life.Altis/core/medical/fn_medicLights.sqf
+++ b/Altis_Life.Altis/core/medical/fn_medicLights.sqf
@@ -24,21 +24,21 @@ _lightLeft setLightAmbient [0.1,0.1,1];
 
 
 //Format: [[left position], [right position]]
-private _offset = switch (typeOf _vehicle) do {
+(switch (typeOf _vehicle) do {
     case "C_Offroad_01_F": {
         [[-0.37, 0.0, 0.56], [0.37, 0.0, 0.56]];
     };
     default {
-        [-1];
+        [[-1], [-1]];
     };
-};
+}) params ["_leftOffset", "_rightOffset"];
 
-if (_offset isEqualTo [-1]) exitWith {
+if (_leftOffset isEqualTo [-1]) exitWith {
     diag_log format ["Vehicle emergency lights not set for: %1",_vehicle];
     hint localize "STR_NOTF_ELSNotSet";
 };
 
-_lightLeft lightAttachObject [_vehicle, _offset select 0];
+_lightLeft lightAttachObject [_vehicle, _leftOffset];
 
 _lightLeft setLightAttenuation [0.181, 0, 1000, 130];
 _lightLeft setLightIntensity 10;
@@ -52,7 +52,7 @@ _lightRight setLightColor _lightBlue;
 _lightRight setLightBrightness 0.2;
 _lightRight setLightAmbient [0.1,0.1,1];
 
-_lightRight lightAttachObject [_vehicle, _offset select 1];
+_lightRight lightAttachObject [_vehicle, _rightOffset];
 
 _lightRight setLightAttenuation [0.181, 0, 1000, 130];
 _lightRight setLightIntensity 10;

--- a/Altis_Life.Altis/core/medical/fn_medicLights.sqf
+++ b/Altis_Life.Altis/core/medical/fn_medicLights.sqf
@@ -22,9 +22,11 @@ _lightLeft setLightColor _lightRed;
 _lightLeft setLightBrightness 0.2;
 _lightLeft setLightAmbient [0.1,0.1,1];
 
+
+//Format: [[left position], [right position]]
 private _offset = switch (typeOf _vehicle) do {
     case "C_Offroad_01_F": {
-        [-0.37, 0.0, 0.56];
+        [[-0.37, 0.0, 0.56], [0.37, 0.0, 0.56]];
     };
     default {
         [-1];
@@ -36,7 +38,7 @@ if (_offset isEqualTo [-1]) exitWith {
     hint localize "STR_NOTF_ELSNotSet";
 };
 
-_lightLeft lightAttachObject [_vehicle, _offset];
+_lightLeft lightAttachObject [_vehicle, _offset select 0];
 
 _lightLeft setLightAttenuation [0.181, 0, 1000, 130];
 _lightLeft setLightIntensity 10;
@@ -50,13 +52,7 @@ _lightRight setLightColor _lightBlue;
 _lightRight setLightBrightness 0.2;
 _lightRight setLightAmbient [0.1,0.1,1];
 
-_offset = switch (typeOf _vehicle) do {
-    case "C_Offroad_01_F": {
-        [0.37, 0.0, 0.56];
-    };
-};
-
-_lightRight lightAttachObject [_vehicle, _offset];
+_lightRight lightAttachObject [_vehicle, _offset select 1];
 
 _lightRight setLightAttenuation [0.181, 0, 1000, 130];
 _lightRight setLightIntensity 10;


### PR DESCRIPTION
Resolves None

#### Changes proposed in this pull request: 
- Removes a switch from each function.
- Swaps both positions to an Array.
- Uses `select` for left and right lightpoint attaching.

- [x] I have tested my changes and corrected any errors found (tested by @Turdant ).
