### PR TITLE
disable ability to slingload storage boxes used for housing (fixes #586)

### DIFF
--- a/Altis_Life.Altis/core/items/fn_placestorage.sqf
+++ b/Altis_Life.Altis/core/items/fn_placestorage.sqf
@@ -19,6 +19,7 @@ detach _container;
 [_container,true] remoteExecCall ["life_fnc_simDisable",RANY];
 _container setPosATL [getPosATL _container select 0, getPosATL _container select 1, (getPosATL _container select 2) + 0.7];
 _container allowDamage false;
+_container enableRopeAttach false;
 
 if ((typeOf _container) == "B_supplyCrate_F") then {
     [false,"storagebig",1] call life_fnc_handleInv;

--- a/life_hc/MySQL/Housing/fn_fetchPlayerHouses.sqf
+++ b/life_hc/MySQL/Housing/fn_fetchPlayerHouses.sqf
@@ -33,6 +33,7 @@ _containerss = [];
     _containerss = _house getVariable ["containers",[]];
     _containerss pushBack _container;
     _container allowDamage false;
+    _container enableRopeAttach false;
     _container setPosATL _position;
     _container setVectorDirAndUp _direction;
     //Fix position for more accurate positioning

--- a/life_server/Functions/Housing/fn_fetchPlayerHouses.sqf
+++ b/life_server/Functions/Housing/fn_fetchPlayerHouses.sqf
@@ -31,6 +31,7 @@ _containerss = [];
     _containerss = _house getVariable ["containers",[]];
     _containerss pushBack _container;
     _container allowDamage false;
+    _container enableRopeAttach false;
     _container setPosATL _position;
     _container setVectorDirAndUp _direction;
     //Fix position for more accurate positioning


### PR DESCRIPTION
Resolves #586 

#### Changes proposed in this pull request: 
Made it so that containers spawned via the storage placement script are not able to be loaded via slingloads.

- [x] I have tested my changes and corrected any errors found

Have not tested this for the bug stated in #586 however I added the line to the same containers via the editor and attempted to slingload them there and could not