### PR TITLE
Fix drinking not working #588

### DIFF
--- a/Altis_Life.Altis/config/Config_vItems.hpp
+++ b/Altis_Life.Altis/config/Config_vItems.hpp
@@ -521,7 +521,7 @@ class VirtualItems {
         buyPrice = 1500;
         sellPrice = 200;
         illegal = false;
-        edible = 100;
+        edible = -1;
         icon = "icons\ico_redgull.paa";
     };
 
@@ -532,7 +532,7 @@ class VirtualItems {
         buyPrice = 10;
         sellPrice = 5;
         illegal = false;
-        edible = 100;
+        edible = -1;
         icon = "icons\ico_coffee.paa";
     };
 
@@ -543,7 +543,7 @@ class VirtualItems {
         buyPrice = 10;
         sellPrice = 5;
         illegal = false;
-        edible = 100;
+        edible = -1;
         icon = "icons\ico_waterBottle.paa";
     };
 

--- a/Altis_Life.Altis/core/init.sqf
+++ b/Altis_Life.Altis/core/init.sqf
@@ -97,7 +97,7 @@ if (LIFE_SETTINGS(getNumber,"pump_service") isEqualTo 1) then {
 };
 
 life_fnc_RequestClientId = player;
-publicVariableServer "life_fnc_RequestClientId"; 
+publicVariableServer "life_fnc_RequestClientId";
 
 /*
     https://feedback.bistudio.com/T117205 - disableChannels settings cease to work when leaving/rejoining mission


### PR DESCRIPTION
Resolves #588 

#### Changes proposed in this pull request: 
- Change `edible=100;` to `edible=-1;` for drinks because - we don't wanna eat them, are we?

- [x] I have tested my changes and corrected any errors found
