### PR TITLE
Vinventory Dupe Fix

### DIFF
--- a/Altis_Life.Altis/SpyGlass/endoftheline.sqf
+++ b/Altis_Life.Altis/SpyGlass/endoftheline.sqf
@@ -5,4 +5,5 @@
     Description:
 
 */
+
 #include "Hi, it appears that your client crashed. Do not worry we will get back with you in six years."

--- a/Altis_Life.Altis/core/vehicle/fn_openInventory.sqf
+++ b/Altis_Life.Altis/core/vehicle/fn_openInventory.sqf
@@ -31,6 +31,13 @@ ctrlSetText[3504,format [(localize "STR_MISC_Weight")+ " %1/%2",_veh_data select
 life_trunk_vehicle = _vehicle;
 
 _vehicle spawn {
+    waitUntil {
+        if ((_this getVariable ["trunk_in_use_by",player]) != player) then {closeDialog 0; hint "Another player tried to open the inventory of that vehicle!"};
+        (isNull (findDisplay 3500))
+    };
+};
+
+_vehicle spawn {
     waitUntil {isNull (findDisplay 3500)};
     _this setVariable ["trunk_in_use",false,true];
     if (_this isKindOf "Box_IND_Grenades_F" || _this isKindOf "B_supplyCrate_F") then {


### PR DESCRIPTION
Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- Fix the bug that allows you to duplicate virtual items using a vehicle or a box with the help of another player. (Opening the virtual inventory at the same time)

- [ ] I have tested my changes and corrected any errors found
