### PR TITLE
Update fn_weaponShopMags to get all available Ammo

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_weaponShopMags.sqf
+++ b/Altis_Life.Altis/core/shops/fn_weaponShopMags.sqf
@@ -9,13 +9,31 @@
 disableSerialization;
 
 if ((uiNamespace getVariable ["Weapon_Magazine",0]) isEqualTo 0) then {
-    private _weapon = lbData[38403,lbCurSel (38403)];
-    private _magArray = FETCH_CONFIG2(getArray,"CfgWeapons",_weapon,"magazines");
+    private ["_weapon","_magArray","_magWell","_subClass","_muzzles"];
+    _weapon = lbData[38403,lbCurSel (38403)];
+    _magArray = FETCH_CONFIG2(getArray,"CfgWeapons",_weapon,"magazines");
+    _magWell = FETCH_CONFIG2(getArray,"CfgWeapons",_weapon,"magazineWell");
+	_muzzles = FETCH_CONFIG2(getArray,"CfgWeapons",_weapon,"muzzles") - ["this"];
     {
-        if (_x in FETCH_CONFIG2(getArray,"CfgWeapons",_weapon,"muzzles")) then {
-            _magArray append FETCH_CONFIG(getArray,"CfgWeapons",_weapon,_x,"magazines");
-        };
-    } count ["EGLM", "GL_3GL_F"];
+		_subClass = _x;
+		{
+			_magArray append getArray ("CfgMagazineWells" >> _subClass >> _x);
+		} count "true" configClasses (configFile >> "CfgMagazineWells" >> _subClass);
+	} count _magWell;
+	
+	//GL and stuff
+	if (count _muzzles > 0) then {
+		{
+			_magArray append FETCH_CONFIG(getArray,"CfgWeapons",_weapon,_x,"magazines");
+			_magWell = FETCH_CONFIG(getArray,"CfgWeapons",_weapon,_x,"magazineWell");
+			{
+			_subClass = _x;
+				{
+					_magArray append getArray("CfgMagazineWells" >> _subClass >> _x);
+				} count "true" configClasses (configFile >> "CfgMagazineWells" >> _subClass);
+			} count _magWell;
+		} count _muzzles;
+	};
     uiNamespace setVariable ["Magazine_Array",_magArray];
     uiNamespace setVariable ["Weapon_Magazine",1];
 } else {


### PR DESCRIPTION
The current version is a hotfix I suggested a while ago. As I just realized, bohemia changed several config entries, so I came up with a way to cover all "muzzles" (all underbarrel weapons) and as using the magazineWell entries, I'm now able to adress all crossover ammo from other mods etc. I'm about to test it asap.

<!-- Please review the guidelines for contributing to this repository. The link is to the right under 'helpful resources'. -->

<!-- It is recommended that changes are committed to a new branch on your fork. Avoid directly editing the `master` branch. -->

Resolves #<!-- issue ID here -->. <!-- If applicable. -->

#### Changes proposed in this pull request: 
- <!-- Describe the changes that your pull request makes. -->

- [ ] I have tested my changes and corrected any errors found
