### PR TITLE
Typo in var inside private array

### DIFF
--- a/life_server/Functions/MySQL/fn_numberSafe.sqf
+++ b/life_server/Functions/MySQL/fn_numberSafe.sqf
@@ -11,7 +11,7 @@
     Returns:
     STRING
 */
-private ["_number","_mod","_digots","_digitsCount","_modBase","_numberText"];
+private ["_number","_mod","_digits","_digitsCount","_modBase","_numberText"];
 
 _number = [_this,0,0,[0]] call bis_fnc_param;
 _mod = [_this,1,3,[0]] call bis_fnc_param;


### PR DESCRIPTION
Renamed "_digots" var which is non-existent to "_digits"