### PR TITLE
fixesJerryCanInterrupt

### DIFF
--- a/Altis_Life.Altis/core/items/fn_jerryRefuel.sqf
+++ b/Altis_Life.Altis/core/items/fn_jerryRefuel.sqf
@@ -55,7 +55,7 @@ life_action_inUse = false;
 "progressBar" cutText ["","PLAIN"];
 player playActionNow "stop";
 if (!alive player) exitWith {};
-if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"];};
+if (life_interrupted) exitWith {life_interrupted = false; titleText[localize "STR_NOTF_ActionCancel","PLAIN"]; [true,"fuelFull",1] call life_fnc_handleInv;};
 
 
 switch (true) do {


### PR DESCRIPTION
Resolves ##687

#### Changes proposed in this pull request: 
- If the action gets interrupted you get a full fuel can back as it hasn't fueled your car.

- [ ] I have tested my changes and corrected any errors found
