### PR TITLE
[master] removed wrong house type

### DIFF
--- a/Altis_Life.Altis/config/Config_Housing.hpp
+++ b/Altis_Life.Altis/config/Config_Housing.hpp
@@ -87,8 +87,6 @@ class Housing {
             lightPos[] = {-3.3,1,2.5};
         };
 
-        class Land_i_House_Small_03_V3_F : Land_i_House_Small_03_V1_F{};
-
         class Land_i_Stone_HouseSmall_V1_F {
             price = 750000;
             numberCrates = 1;


### PR DESCRIPTION
#### Changes proposed in this pull request: 
- remove Land_i_House_Small_03_V3_F from Config_Housing.hpp

- [x] I have tested my changes and corrected any errors found

according to https://community.bistudio.com/wiki/Arma_3_CfgVehicles_Structures and https://community.bistudio.com/wiki/Arma_3_CfgPatches_CfgVehicles there's only one type:
Land_i_House_Small_03_V1_F