### PR TITLE
[master] fix north-east air shop

### DIFF
--- a/SQMs/missionAltis.sqm
+++ b/SQMs/missionAltis.sqm
@@ -32257,7 +32257,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="this enableSimulation false; this allowDamage false; this addAction[localize""STR_MAR_Helicopter_Shop"", life_fnc_vehicleShopMenu,[""civ_air"",civilian,[""civ_air_2"",""civ_air_2_1""],""civ"",""Carl's Airial Auto's""],1.5,true,true,"""",""true"",5];";
+						init="this enableSimulation false; this allowDamage false; this addAction[localize""STR_MAR_Helicopter_Shop"", life_fnc_vehicleShopMenu,[""civ_air"",civilian,[""civ_air_2"",""civ_air_2_2""],""civ"",""Carl's Airial Auto's""],1.5,true,true,"""",""true"",5];";
 						disableSimulation=1;
 					};
 					id=974;


### PR DESCRIPTION
Resolves (not applicable)

#### Changes proposed in this pull request: 
- civ_air_2_1 does not exists - so the script "spawns" vehicles into "the void" when civ_air_2 is blocked
as vehicles never spawnt in they don't get picked up by fn_cleanup but only after server restart

- [x] I have tested my changes and corrected any errors found