### PR TITLE
re-add of localize for formating _crime

### DIFF
--- a/Altis_Life.Altis/core/pmenu/fn_wantedInfo.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_wantedInfo.sqf
@@ -24,7 +24,7 @@ private _crimes = _data select 0;
     _crime = _x;
     if !(_crime in _mylist) then {
         _mylist pushBack _crime;
-        _list lbAdd format [localize "STR_Wanted_Count",{_x == _crime} count _crimes,_crime];
+        _list lbAdd format [localize "STR_Wanted_Count",{_x == _crime} count _crimes,localize _crime];
     };
 } forEach _crimes;
 


### PR DESCRIPTION
Resolves #none

#### Changes proposed in this pull request: 
- _crime in the loop which counts the number of crimes is the stringtable key id STR_Crime_xxx - localize is needed here to have the actual crime end up in the list instead of it's key id

- [x] I have tested my changes and corrected any errors found