### PR TITLE
Fix - purchase virtual items with gang money

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_weaponShopSelection.sqf
+++ b/Altis_Life.Altis/core/shops/fn_weaponShopSelection.sqf
@@ -55,32 +55,9 @@ if ((uiNamespace getVariable ["Weapon_Shop_Filter",0]) isEqualTo 1) then {
                 //Accessories Menu
                 if (isClass (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo")) then {
                     private ["_slotArray"];
-                    _itemArray = [];
-                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "CowsSlot" >> "compatibleItems")) then {
-                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","CowsSlot","compatibleItems");
-                        {
-                            _itemArray pushBack _x;
-                        } forEach _slotArray;
-                    };
-                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "MuzzleSlot" >> "compatibleItems")) then {
-                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","MuzzleSlot","compatibleItems");
-                        {
-                            _itemArray pushBack _x;
-                        } forEach _slotArray;
-                    };
-                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "PointerSlot" >> "compatibleItems")) then {
-                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","PointerSlot","compatibleItems");
-                        {
-                            _itemArray pushBack _x;
-                        } forEach _slotArray;
-                    };
-                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "UnderBarrelSlot" >> "compatibleItems")) then {
-                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","UnderBarrelSlot","compatibleItems");
-                        {
-                            _itemArray pushBack _x;
-                        } forEach _slotArray;
-                    };
-
+					
+                    _itemArray = _item call BIS_fnc_compatibleItems;
+					
                     _bool = false;
                     {
                         _var = _x select 0;

--- a/Altis_Life.Altis/core/shops/fn_weaponShopSelection.sqf
+++ b/Altis_Life.Altis/core/shops/fn_weaponShopSelection.sqf
@@ -55,9 +55,32 @@ if ((uiNamespace getVariable ["Weapon_Shop_Filter",0]) isEqualTo 1) then {
                 //Accessories Menu
                 if (isClass (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo")) then {
                     private ["_slotArray"];
-					
-                    _itemArray = _item call BIS_fnc_compatibleItems;
-					
+                    _itemArray = [];
+                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "CowsSlot" >> "compatibleItems")) then {
+                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","CowsSlot","compatibleItems");
+                        {
+                            _itemArray pushBack _x;
+                        } forEach _slotArray;
+                    };
+                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "MuzzleSlot" >> "compatibleItems")) then {
+                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","MuzzleSlot","compatibleItems");
+                        {
+                            _itemArray pushBack _x;
+                        } forEach _slotArray;
+                    };
+                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "PointerSlot" >> "compatibleItems")) then {
+                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","PointerSlot","compatibleItems");
+                        {
+                            _itemArray pushBack _x;
+                        } forEach _slotArray;
+                    };
+                    if (isArray (configFile >> "CfgWeapons" >> _item >> "WeaponSlotsInfo" >> "UnderBarrelSlot" >> "compatibleItems")) then {
+                        _slotArray = FETCH_CONFIG3(getArray,"CfgWeapons",_item,"WeaponSlotsInfo","UnderBarrelSlot","compatibleItems");
+                        {
+                            _itemArray pushBack _x;
+                        } forEach _slotArray;
+                    };
+
                     _bool = false;
                     {
                         _var = _x select 0;

--- a/Altis_Life.Altis/dialog/shop_items.hpp
+++ b/Altis_Life.Altis/dialog/shop_items.hpp
@@ -107,7 +107,7 @@ class shops_menu {
             idc = -1;
             text = "$STR_VS_BuyItem";
             colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.3843])", "(profilenamespace getvariable ['GUI_BCG_RGB_G',0.7019])", "(profilenamespace getvariable ['GUI_BCG_RGB_B',0.8862])", 0.5};
-            onButtonClick = "[] call life_fnc_virt_buy;";
+            onButtonClick = "[] spawn life_fnc_virt_buy";
             x = 0.12 + (0.35 / 2) - ((6.25 / 40) / 2);
             y = 0.70;
             w = (6.25 / 40);
@@ -128,7 +128,7 @@ class shops_menu {
         class ButtonClose: Life_RscButtonMenu {
             idc = -1;
             text = "$STR_Global_Close";
-            onButtonClick = "closeDialog 0;";
+            onButtonClick = "closeDialog 0";
             x = 0.1;
             y = 0.8 - (1 / 25);
             w = (6.25 / 40);


### PR DESCRIPTION
Fixed an issue when purchasing virtual items in gang hideouts, where the player could buy items without spending the gang's money.

Resolves #. 

#### Changes proposed in this pull request: 
Switch from call to spawn on the action of the button in the dialog code. The "BIS_fnc_GUImessage" function cannot be used in scripts executed with "call".

- [x] I have tested my changes and corrected any errors found
