### PR TITLE
Stops people from glitching into Commander View

### DIFF
--- a/Altis_Life.Altis/SpyGlass/fn_menuCheck.sqf
+++ b/Altis_Life.Altis/SpyGlass/fn_menuCheck.sqf
@@ -128,6 +128,15 @@ for "_i" from 0 to 1 step 0 do {
         sleep 0.5;
         failMission "SpyGlass";
     };
+    
+    if (LIFE_SETTINGS(getNumber,"disableCommanderView") isEqualTo 1) then {
+        if (cameraView isEqualTo "GROUP") then {
+            [profileName,getPlayerUID player,"Entered_commander_view"] remoteExec ["SPY_fnc_cookieJar",RSERV];
+            [profileName,"Entered commander view"] remoteExec ["SPY_fnc_notifyAdmins",RCLIENT];
+            sleep 0.5;
+            failMission "SpyGlass";
+        };
+    };
 
     /*
         Display Validator

--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -98,6 +98,10 @@ switch (_code) do {
             hint localize "STR_NOTF_CommanderView";
             _handled = true;
         };
+        
+        if (_code in (actionKeys "Diary")) then {
+            _handled = true;
+        };
     };
 
     //Space key for Jumping


### PR DESCRIPTION
Stops people from opening the Diary Menu which could be used for glitching into the commander view by opening the diary menu first and then entering commander view. Also adds an additional SpyGlass check which will kick players that enters the commander view when it is disabled.